### PR TITLE
Remove hardcoded CSS for dropdown selected text colors

### DIFF
--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -241,7 +241,6 @@ void initComboBox(QComboBox* combo, QLineEdit* lineEdit, QString cssClass)
         lineEdit->setAlignment(Qt::AlignRight);
         combo->setLineEdit(lineEdit);
     }
-    combo->setStyleSheet("selection-background-color:transparent; selection-color:transparent;");
     combo->setView(new QListView());
 }
 


### PR DESCRIPTION
The C++ code had hardcoded stylesheet attributes for dropdowns to have transparent text when the text was selected. This caused dropdown headers to seem to disappear when double-clicked. This will remove that hardcoding so the stylesheets can control it.

This PR can be pushed to all coin develop (or design) branches. The stylesheets are being updated now.