### PR TITLE
fix stake chart date range end date

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -506,12 +506,12 @@ void DashboardWidget::updateStakeFilter()
                 QDate monthFirst = QDate(yearFilter, monthFilter, 1);
                 stakesFilter->setDateRange(
                         QDateTime(monthFirst),
-                        QDateTime(QDate(yearFilter, monthFilter, monthFirst.daysInMonth()))
+                        QDateTime(QDate(yearFilter, monthFilter, monthFirst.daysInMonth())).addDays(1).addMSecs(-1);
                 );
             } else {
                 stakesFilter->setDateRange(
                         QDateTime(QDate(yearFilter, 1, 1)),
-                        QDateTime(QDate(yearFilter, 12, 31))
+                        QDateTime(QDate(yearFilter, 12, 31)).addDays(1).addMSecs(-1);
                 );
             }
         } else if (filterByMonth) {
@@ -519,7 +519,7 @@ void DashboardWidget::updateStakeFilter()
             QDate monthFirst = QDate(currentDate.year(), monthFilter, 1);
             stakesFilter->setDateRange(
                     QDateTime(monthFirst),
-                    QDateTime(QDate(currentDate.year(), monthFilter, monthFirst.daysInMonth()))
+                    QDateTime(QDate(currentDate.year(), monthFilter, monthFirst.daysInMonth())).addDays(1).addMSecs(-1);
             );
             ui->comboBoxYears->setCurrentText(QString::number(currentDate.year()));
         } else {


### PR DESCRIPTION
Add time portion to date range end date to include all transactions occurring on that date. Previously no time portion was used in the date creation, so it was defaulting to midnight. This caused the range to not including anything occurring on that end date so charts would never show anything for the last day of month (or last day of year for the yearly chart, but that was not as obvious as the day view).