### PR TITLE
[DSW] Non mandatory enhancement - add warning message when run dumpwallet or dumpprivkey

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -253,7 +253,8 @@ void RPCExecutor::requestCommand(const QString& command)
 }
 
 bool RPCExecutor::settingsCommandNeedsWarning(const std::string& command)
-{
+{   //Note: There is a duplicate of this functionionality for the old style RPC console. Any changes here should also be replicated in src/qt/rpcconsole.cpp
+
     /*  If command was executed already, return false regardless of the command as we would have already warned user if it was dangerous */
     if(settingsCommandCallCount.count(command) > 0 && settingsCommandCallCount.at(command) > 0) {
         return false;
@@ -263,7 +264,8 @@ bool RPCExecutor::settingsCommandNeedsWarning(const std::string& command)
 }
 
 QString RPCExecutor::settingsGetCommandWarning(const std::string& command)
-{
+{   //Note: There is a duplicate of this functionionality for the old style RPC console. Any changes here should also be replicated in src/qt/rpcconsole.cpp
+
     if(command == "dumpprivkey") {
         return "Warning: This command will print your private key! If someone\n"
                 "gains access to this key you will lose all your coins! Hackers/Scammers\n"

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -266,7 +266,8 @@ void RPCExecutor::request(const QString& command)
 }
 
 bool RPCExecutor::commandNeedsWarning(const std::string& command)
-{
+{   //Note: There is a duplicate of this functionionality in the new GUI integrated RPC console. Any changes here should also be replicated in src/qt/pivx/settings/settingsconsolewidget.cpp
+
     /*  If command was executed already, return false regardless of the command as we would have already warned user if it was dangerous */
     if(commandCallCount.count(command) > 0 && commandCallCount.at(command) > 0) {
         return false;
@@ -276,7 +277,8 @@ bool RPCExecutor::commandNeedsWarning(const std::string& command)
 }
 
 QString RPCExecutor::getCommandWarning(const std::string& command)
-{
+{   //Note: There is a duplicate of this functionionality in the new GUI integrated RPC console. Any changes here should also be replicated in src/qt/pivx/settings/settingsconsolewidget.cpp
+
     if(command == "dumpprivkey") {
         return "Warning: This command will print your private key! If someone\n"
                 "gains access to this key you will lose all your coins! Hackers/Scammers\n"


### PR DESCRIPTION
Add a warning message to display on the rpc console the first time the user runs dumpwallet or dumpprivkey.  Successive runs of the command will not trigger the warning message.