### PR TITLE
add support for designated default outbound IP

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   wallet/db.h \
   fs.h \
   hash.h \
+  hostip.h \
   httprpc.h \
   httpserver.h \
   init.h \
@@ -436,6 +437,7 @@ libbitcoin_common_a_SOURCES = \
   core_read.cpp \
   core_write.cpp \
   hash.cpp \
+  hostip.cpp \
   invalid.cpp \
   key.cpp \
   keystore.cpp \

--- a/src/hostip.cpp
+++ b/src/hostip.cpp
@@ -1,0 +1,146 @@
+// Copyright (C) 2000-2010  Daniel Ryde
+// Copyright (c) 2021-2022 The DECENOMY Core Developers
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+#include "hostip.h"
+#include "chainparams.h"
+#include "tinyformat.h"
+#include "guiinterface.h"
+#include "guiinterfaceutil.h"
+
+HostIP hostip;
+
+bool HostIP::init(std::string bindAddr)
+{
+    if (bindAddr.empty()) return false;
+
+    std::string strHost;
+    int nDefaultPort = Params().GetDefaultPort();
+    int port = 0;
+    SplitHostPort(bindAddr, port, strHost);
+    service = CService();
+// only to allow bitcoind rpc port to listen on 0.0.0.0
+//    if (port == 0) port = nDefaultPort;
+    if (!Lookup(strHost.c_str(), service, port, true))
+    {
+        return UIError(strprintf(_("HostIP: invalid bindAddr %s\n"), bindAddr));
+    }
+    hostipport = htons((unsigned short)port);
+
+    std::string strError = "";
+    socklen_t len = sizeof(sockaddr);
+
+    if (!service.GetSockAddr((struct sockaddr*)&local_sockaddr, &len))
+    {
+        return UIError(strprintf(_("Error: Address family for %s not supported\n"), service.ToString()));
+    }
+
+    if (service.IsIPv4())
+    {
+        inaddr_any_saddr = htonl (INADDR_ANY);
+        len = sizeof(struct sockaddr_in);
+        struct sockaddr_in *paddrin = (struct sockaddr_in*) &local_sockaddr;
+        memset(paddrin, 0, len);
+        if (!service.GetInAddr(&paddrin->sin_addr))
+        {
+            return UIError(strprintf(_("Error: Invalid address\n"), service.ToString()));
+        }
+        fHostIP = true;
+        paddrin->sin_family = AF_INET;
+        paddrin->sin_port = htons(0);
+    } else {	// is IPv
+        len = sizeof(struct sockaddr_in6);
+        struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*) &local_sockaddr;
+        memset(paddrin6, 0, len);
+        if (!service.GetIn6Addr(&paddrin6->sin6_addr))
+        {
+            return UIError(strprintf(_("Error: Invalid address\n"), service.ToString()));
+        }
+        fHostIP = true;
+        fIsIPv4 = false;
+        paddrin6->sin6_scope_id = 0;
+        paddrin6->sin6_family = AF_INET6;
+        paddrin6->sin6_port = htons(0);
+    }
+}
+
+// substitute this for ::bind in net.cpp
+int HostIP::altbind(SOCKET ufd, struct sockaddr * sk, socklen_t sl)
+{
+    static struct sockaddr_in *lsk_in;
+    static struct sockaddr_in6 *lsk6_in;
+    static struct in6_addr addr6;
+
+    if (fIsIPv4)
+    {
+        lsk_in = (struct sockaddr_in *)sk;
+        unsigned long int addr;
+        if (fHostIP
+            && (lsk_in->sin_family == AF_INET)
+            && (lsk_in->sin_port != hostipport)
+            && (lsk_in->sin_addr.s_addr == inaddr_any_saddr)
+            && service.GetInAddr((in_addr*)&addr))
+        {
+            lsk_in->sin_addr.s_addr = addr;
+        }
+    }
+    else 
+    { // is IPv6
+        lsk6_in = (struct sockaddr_in6 *)sk;
+
+        if (fHostIP
+            && (lsk6_in->sin6_family == AF_INET6)
+            && (lsk6_in->sin6_port != hostipport)
+            && IsInAddrAny6(lsk6_in)
+            && service.GetIn6Addr(&addr6))
+        {
+            memcpy(&(lsk6_in->sin6_addr), &addr6, 16);
+        }
+    }
+    return ::bind(ufd, sk, sl);
+}
+
+// insert this just before for "connect" in netbase.cpp
+int HostIP::alteraddr(SOCKET ufd, struct sockaddr * sk, socklen_t sl)
+{
+    static struct sockaddr_in *rsk_in;
+    static struct sockaddr_in6 *rsk6_in;
+
+    if (fIsIPv4)
+    {
+        rsk_in = (struct sockaddr_in *)sk;
+        if (fHostIP
+            && (rsk_in->sin_family == AF_INET)
+            && (rsk_in->sin_port != hostipport))
+        {
+            ::bind(ufd, (struct sockaddr *)&local_sockaddr, sizeof(struct sockaddr));
+        }
+    }
+    else 
+    { // is IPv6
+        rsk6_in = (struct sockaddr_in6 *)sk;
+
+        if (fHostIP
+            && (rsk6_in->sin6_family == AF_INET6)
+            && (rsk6_in->sin6_port != hostipport))
+        {
+            ::bind(ufd, (struct sockaddr *)&local_sockaddr, sizeof(struct sockaddr));
+        }
+    }
+}
+
+bool HostIP::IsInAddrAny6(struct sockaddr_in6 * sin6)
+{
+    int i;
+    uint32_t * pa = reinterpret_cast<uint32_t*>(sin6);
+    for(i = 0; i < 4; ++i)
+    {
+        if (*pa != 0)
+            return false;
+        *pa++;
+    }
+    return true;
+}

--- a/src/hostip.h
+++ b/src/hostip.h
@@ -31,9 +31,8 @@ private:
 
 public:
     CService service;
-    int altbind(SOCKET sock, struct sockaddr * sk, socklen_t sl);
     int alteraddr(SOCKET sock, struct sockaddr * sk, socklen_t sl);
-    bool init(std::string bindAddr);
+    bool init(std::string hostIpAddr);
     bool IsInAddrAny6(struct sockaddr_in6 * sin6);
 };
 

--- a/src/hostip.h
+++ b/src/hostip.h
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2021-2022 The DECENOMY Core Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef HOSTIP_H
+#define HOSTIP_H
+
+#if defined(HAVE_CONFIG_H)
+#include "config/pivx-config.h"
+#endif
+
+#include "compat.h"
+#include "serialize.h"
+#include "netaddress.h"
+#include "netbase.h"
+
+#include <stdint.h>
+#include <string>
+
+class HostIP;
+
+extern HostIP hostip;
+
+class HostIP {
+private:
+    bool fHostIP = false;
+    bool fIsIPv4 = true;
+    unsigned long int inaddr_any_saddr;
+    unsigned short hostipport = 0;
+    struct sockaddr_storage local_sockaddr;
+
+public:
+    CService service;
+    int altbind(SOCKET sock, struct sockaddr * sk, socklen_t sl);
+    int alteraddr(SOCKET sock, struct sockaddr * sk, socklen_t sl);
+    bool init(std::string bindAddr);
+    bool IsInAddrAny6(struct sockaddr_in6 * sin6);
+};
+
+#endif // HOSTIP_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,6 +25,7 @@
 #include "consensus/upgrades.h"
 #include "consensus/zerocoin_verify.h"
 #include "fs.h"
+#include "hostip.h"
 #include "httpserver.h"
 #include "httprpc.h"
 #include "invalid.h"
@@ -430,6 +431,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dnsseed", _("Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)"));
     strUsage += HelpMessageOpt("-externalip=<ip>", _("Specify your own public address"));
     strUsage += HelpMessageOpt("-forcednsseed", strprintf(_("Always query for peer addresses via DNS lookup (default: %u)"), DEFAULT_FORCEDNSSEED));
+    strUsage += HelpMessageOpt("-hostip=<ip>", _("Specify default host IP for outbound connections"));
     strUsage += HelpMessageOpt("-listen", strprintf(_("Accept connections from outside (default: %u if no -proxy or -connect/-noconnect)"), DEFAULT_LISTEN));
     strUsage += HelpMessageOpt("-listenonion", strprintf(_("Automatically create Tor hidden service (default: %d)"), DEFAULT_LISTEN_ONION));
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), DEFAULT_MAX_PEER_CONNECTIONS));
@@ -1394,6 +1396,13 @@ bool AppInit2()
     // see Step 2: parameter interactions for more information about these
     fListen = GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = GetBoolArg("-discover", true);
+
+    if (mapArgs.count("-hostip"))
+    {
+        std::string hostipArg = GetArg("-hostip", "");
+        if (!hostip.init(hostipArg)) return false;
+        LogPrintf("host IP address %s\n",hostip.service.ToString().c_str());
+    }
 
     bool fBound = false;
     if (fListen) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -19,7 +19,6 @@
 #include "crypto/sha256.h"
 #include "guiinterface.h"
 #include "hash.h"
-#include "hostip.h"
 #include "main.h"
 #include "masternodeman.h"
 #include "miner.h"
@@ -2013,8 +2012,7 @@ bool CConnman::BindListenPort(const CService& addrBind, std::string& strError, b
 #endif
     }
 
-//    if (::bind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
-    if (hostip.altbind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
+    if (::bind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
             strError = strprintf(_("Unable to bind to %s on this computer. Kyanite is probably already running."), addrBind.ToString());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -19,6 +19,7 @@
 #include "crypto/sha256.h"
 #include "guiinterface.h"
 #include "hash.h"
+#include "hostip.h"
 #include "main.h"
 #include "masternodeman.h"
 #include "miner.h"
@@ -2012,7 +2013,8 @@ bool CConnman::BindListenPort(const CService& addrBind, std::string& strError, b
 #endif
     }
 
-    if (::bind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
+//    if (::bind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
+    if (hostip.altbind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
             strError = strprintf(_("Unable to bind to %s on this computer. Kyanite is probably already running."), addrBind.ToString());

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -13,6 +13,7 @@
 
 #include "hash.h"
 #include "sync.h"
+#include "hostip.h"
 #include "uint256.h"
 #include "random.h"
 #include "util.h"
@@ -493,7 +494,10 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
     if (!SetSocketNonBlocking(hSocket, true))
         return error("ConnectSocketDirectly: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
 
+    hostip.alteraddr(hSocket, (struct sockaddr*)&sockaddr, len);
+
     if (connect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
+//    if (hostip.altconnect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         // WSAEINVAL is here because some legacy version of winsock uses it
         if (nErr == WSAEINPROGRESS || nErr == WSAEWOULDBLOCK || nErr == WSAEINVAL) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -494,10 +494,10 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
     if (!SetSocketNonBlocking(hSocket, true))
         return error("ConnectSocketDirectly: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
 
+// check for designated outbound IP address and use it if present
     hostip.alteraddr(hSocket, (struct sockaddr*)&sockaddr, len);
 
     if (connect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
-//    if (hostip.altconnect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         // WSAEINVAL is here because some legacy version of winsock uses it
         if (nErr == WSAEINPROGRESS || nErr == WSAEWOULDBLOCK || nErr == WSAEINVAL) {


### PR DESCRIPTION
Designate the outbound IP address of the daemon rather than allowing the daemon to use the default address provided on the ethernet device. This is useful to allow both kyanite-qt and kyanited to run on the same host.