### PR TITLE
[WIP][QT][RPC] 2FA Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ src/__decenomy__-tx
 src/bench/bench___decenomy__
 src/test/test___decenomy__
 src/qt/test/test___decenomy__-qt
+depends/sdk-sources/*
+depends/SDKs/*
 
 # Sapphire
 src/bench/bench_sapphire

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -48,6 +48,7 @@ QT_FORMS_UI = \
   qt/pivx/forms/tooltipmenu.ui \
   qt/pivx/forms/addresseswidget.ui \
   qt/pivx/forms/defaultdialog.ui \
+  qt/pivx/forms/defaultotpdialog.ui \
   qt/pivx/settings/forms/settingsbackupwallet.ui \
   qt/pivx/settings/forms/settingsexportcsv.ui \
   qt/pivx/settings/forms/settingsbittoolwidget.ui \
@@ -133,6 +134,7 @@ QT_MOC_CPP = \
   qt/pivx/moc_tooltipmenu.cpp \
   qt/pivx/moc_addresseswidget.cpp \
   qt/pivx/moc_defaultdialog.cpp \
+  qt/pivx/moc_defaultotpdialog.cpp \
   qt/pivx/settings/moc_settingsbackupwallet.cpp \
   qt/pivx/settings/moc_settingsexportcsv.cpp \
   qt/pivx/settings/moc_settingsbittoolwidget.cpp \
@@ -251,6 +253,7 @@ BITCOIN_QT_H = \
   qt/pivx/tooltipmenu.h \
   qt/pivx/addresseswidget.h \
   qt/pivx/defaultdialog.h \
+  qt/pivx/defaultotpdialog.h \
   qt/pivx/settings/settingsbackupwallet.h \
   qt/pivx/settings/settingsexportcsv.h \
   qt/pivx/settings/settingsbittoolwidget.h \
@@ -552,6 +555,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/pivx/tooltipmenu.cpp \
   qt/pivx/addresseswidget.cpp \
   qt/pivx/defaultdialog.cpp \
+  qt/pivx/defaultotpdialog.cpp \
   qt/pivx/settings/settingsbackupwallet.cpp \
   qt/pivx/settings/settingsexportcsv.cpp \
   qt/pivx/settings/settingsbittoolwidget.cpp \

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -160,7 +160,7 @@ public:
 
     bool IsLocked() const
     {
-        if (!IsCrypted())
+        if ((!IsCrypted()) || (!IsCrypted() && !IsOTP()))
             return false;
         bool result;
         {
@@ -170,13 +170,18 @@ public:
         return result;
     }
 
+    bool IsOTP() const
+    {
+        return fUseCrypto;
+    }
+
     virtual bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
     bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);
     bool HaveKey(const CKeyID& address) const
     {
         {
             LOCK(cs_KeyStore);
-            if (!IsCrypted())
+            if ((!IsCrypted()) || (!IsCrypted() && !IsOTP()))
                 return CBasicKeyStore::HaveKey(address);
             return mapCryptedKeys.count(address) > 0;
         }
@@ -187,7 +192,7 @@ public:
     void GetKeys(std::set<CKeyID>& setAddress) const
     {
         LOCK(cs_KeyStore);
-        if (!IsCrypted()) {
+        if ((!IsCrypted()) || (!IsCrypted() && !IsOTP())) {
             CBasicKeyStore::GetKeys(setAddress);
             return;
         }

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -11,7 +11,8 @@
 #include "keystore.h"
 #include "serialize.h"
 #include "streams.h"
-#include <filesystem>
+#include "fs.h"
+#include "util.h"
 
 class uint256;
 
@@ -173,7 +174,8 @@ public:
 
     bool IsOTP() const
     {
-        if(fs::exists(seedpath))
+        fs::path seedPath = GetDataDir() / DEFAULT_OTP_FILENAME;
+        if(fs::exists(seedPath))
             return true;
         return false;
     }

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -11,6 +11,7 @@
 #include "keystore.h"
 #include "serialize.h"
 #include "streams.h"
+#include <filesystem>
 
 class uint256;
 
@@ -172,7 +173,9 @@ public:
 
     bool IsOTP() const
     {
-        return fUseCrypto;
+        if(fs::exists(seedpath))
+            return true;
+        return false;
     }
 
     virtual bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1088,6 +1088,9 @@ bool AppInit2()
     if (!CWallet::ParameterInteraction())
         return false;
 #endif // ENABLE_WALLET
+    std::string strOtpFile = GetArg("-otp", DEFAULT_OTP_FILENAME);
+    if (!CWallet::ParameterInteraction())
+        return false;
 
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -191,7 +191,7 @@ void AskPassphraseDialog::onGenerateSeedClicked()
         QPixmap otpQr = encodeToQr(str, error, qrColor);
         openStandardDialog(
             tr("2FA SEED"),
-            tr("%1"),
+            tr("%1").arg(str),
             tr("Done"),
             tr("Cancel")
         );
@@ -267,7 +267,7 @@ void AskPassphraseDialog::accept()
                         tr("Used: %1, Generated: %2")
                             .arg(otpcode)
                             .arg(validatepin));
-                } else {
+                } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 
                         tr("OTP Code Success"), 
                         tr("Used: %1, Generated: %2");

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -271,9 +271,10 @@ void AskPassphraseDialog::accept()
                 if (validatepin != otpcode) {
                     QMessageBox::information(this, 
                         tr("Invalid OTP Code"), 
-                        tr("Used: %1, Generated: %2")
+                        tr("Used: %1, Generated: %2 Seed: %3")
                             .arg(otpcode)
                             .arg(validatepin)
+                            .arg(otpcodeChar)
                             );
                 } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -274,7 +274,7 @@ void AskPassphraseDialog::accept()
         if(addOTP && !otpStr.empty()) {
             otpcode = std::stoi(otpStr);
             fs::path otpDir = GetDataDir() / DEFAULT_OTP_FILENAME;
-            std::string otpDirStr = path.string();
+            std::string otpDirStr = otpDir.string();
             std::ifstream file(otpDirStr);
             if(file) {
                 std::string temp;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -293,9 +293,10 @@ void AskPassphraseDialog::accept()
         break;
     case Mode::AddOTP:
         std::string newOTPSeed = GoogleAuthenticator::CreateNewSeed();
+        QString str = QString::fromStdString(newOTPSeed);
         QMessageBox::critical(this, 
                             tr("Save this 2FA Seed"), 
-                            tr("%1").arg(newOTPSeed));
+                            tr("%1").arg(str));
         break;
     }
 }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -210,15 +210,15 @@ void AskPassphraseDialog::generateSeed()
             QString str = QString::fromStdString(newOTPSeed);
             // Precursor to QRCode for the OTP Seed
             // TODO: Modify openStandardDialog to have a label for qpixmap insertion
-            QString error;
-            QColor qrColor("#382d4d");
-            QPixmap otpQr = encodeToQr(str, error, qrColor);
+            //QString error;
+            //QColor qrColor("#382d4d");
+            //QPixmap otpQr = encodeToQr(str, error, qrColor);
             openOtpDialog(
                 tr("2FA SEED"),
                 tr("%1").arg(charOTP),
                 tr("Done"),
                 tr("Cancel"),
-                tr("%2").arg(otpQr)
+                tr("%2").arg(str)
 
             );
             fwrite(charOTP, std::strlen(charOTP), 1, file);
@@ -420,12 +420,15 @@ bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QStrin
     return ret;
 }
 
-bool AskPassphraseDialog::openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QPixmap qrOtp)
+bool AskPassphraseDialog::openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QString qrOtp)
 {
+    QString error;
+    QColor qrColor("#382d4d");
+    QPixmap qrCode = encodeToQr(qrOtp, error, qrColor);
     PIVXGUI* gui = static_cast<PIVXGUI*>(parentWidget());
     DefaultOtpDialog *confirmDialog = new DefaultOtpDialog(gui);
     confirmDialog->setText(title, body, okBtn, cancelBtn);
-    confirmDialog->setQrCode(qrOtp);
+    confirmDialog->setQrCode(qrCode);
     confirmDialog->adjustSize();
     openDialogWithOpaqueBackground(confirmDialog, gui);
     bool ret = confirmDialog->isOk;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -9,6 +9,7 @@
 #include "ui_askpassphrasedialog.h"
 #include <QGraphicsDropShadowEffect>
 
+#include "fs.h"
 #include "guiconstants.h"
 #include "guiutil.h"
 #include "walletmodel.h"
@@ -17,9 +18,9 @@
 #include "qt/pivx/loadingdialog.h"
 #include "qt/pivx/defaultdialog.h"
 #include "qt/pivx/pivxgui.h"
+#include "wallet/wallet.h"
 #include <stdio.h>
 #include <iostream>
-#include "fs.h"
 #include <string>
 #include <cstdlib>
 #include <QDebug>
@@ -281,7 +282,7 @@ void AskPassphraseDialog::accept()
         );
         if(addOTP && !otpStr.empty()) {
             otpcode = std::stoi(otpStr);
-            otpEnabled = Validate2fa(otpcode);
+            otpEnabled = CWallet::Validate2fa(otpcode);
         }
         if ((ret && !otpEnabled) || (ret && otpEnabled)) {
             newpassCache = newpass1;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -215,7 +215,7 @@ void AskPassphraseDialog::generateSeed()
                 tr("Done"),
                 tr("Cancel")
             );
-            fprintf(file, "%i\n", str.toInt());
+            fwrite(str.c_str(), std::strlen(str), 1, file);
             fclose(file);
         }
 }
@@ -275,7 +275,7 @@ void AskPassphraseDialog::accept()
             FILE* file = fsbridge::fopen(path, "rb");
             char otpCheck [30];
             if(file) {
-                std::string otpcodeChar = fgets(otpCheck, 30, file);
+                std::string otpcodeChar = fread(otpCheck, 1, sizeof(otpCheck), file);
                 int validatepin = GoogleAuthenticator(otpcodeChar).GeneratePin();
                 if (validatepin != otpcode) {
                     QMessageBox::information(this, 

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -17,6 +17,7 @@
 #include "qt/pivx/qtutils.h"
 #include "qt/pivx/loadingdialog.h"
 #include "qt/pivx/defaultdialog.h"
+#include "qt/pivx/defaultotpdialog.h"
 #include "qt/pivx/pivxgui.h"
 #include "wallet/wallet.h"
 #include <stdio.h>
@@ -212,11 +213,13 @@ void AskPassphraseDialog::generateSeed()
             QString error;
             QColor qrColor("#382d4d");
             QPixmap otpQr = encodeToQr(str, error, qrColor);
-            openStandardDialog(
+            openOtpDialog(
                 tr("2FA SEED"),
                 tr("%1").arg(charOTP),
                 tr("Done"),
-                tr("Cancel")
+                tr("Cancel"),
+                tr("%2").arg(otpQr)
+
             );
             fwrite(charOTP, std::strlen(charOTP), 1, file);
             fclose(file);
@@ -410,6 +413,19 @@ bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QStrin
     PIVXGUI* gui = static_cast<PIVXGUI*>(parentWidget());
     DefaultDialog *confirmDialog = new DefaultDialog(gui);
     confirmDialog->setText(title, body, okBtn, cancelBtn);
+    confirmDialog->adjustSize();
+    openDialogWithOpaqueBackground(confirmDialog, gui);
+    bool ret = confirmDialog->isOk;
+    confirmDialog->deleteLater();
+    return ret;
+}
+
+bool AskPassphraseDialog::openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QPixmap qrOtp)
+{
+    PIVXGUI* gui = static_cast<PIVXGUI*>(parentWidget());
+    DefaultOtpDialog *confirmDialog = new DefaultOtpDialog(gui);
+    confirmDialog->setText(title, body, okBtn, cancelBtn);
+    confirmDialog->setQrCode(qrOtp);
     confirmDialog->adjustSize();
     openDialogWithOpaqueBackground(confirmDialog, gui);
     bool ret = confirmDialog->isOk;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -424,11 +424,11 @@ bool AskPassphraseDialog::openOtpDialog(QString title, QString body, QString okB
 {
     QString error;
     QColor qrColor("#382d4d");
-    QPixmap qrCode = encodeToQr(qrOtp, error, qrColor);
+    QPixmap qrCode = encodeToOtpQr(qrOtp, error, qrColor);
     PIVXGUI* gui = static_cast<PIVXGUI*>(parentWidget());
     DefaultOtpDialog *confirmDialog = new DefaultOtpDialog(gui);
     confirmDialog->setText(title, body, okBtn, cancelBtn);
-    confirmDialog->setQrCode(qrCode);
+    confirmDialog->setQrCode(qrOtp,error,qrColor);
     confirmDialog->adjustSize();
     openDialogWithOpaqueBackground(confirmDialog, gui);
     bool ret = confirmDialog->isOk;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -227,7 +227,8 @@ void AskPassphraseDialog::showEvent(QShowEvent *event)
 
 void AskPassphraseDialog::accept()
 {
-    SecureString oldpass, newpass1, newpass2, otpcode, otpcode1;
+    SecureString oldpass, newpass1, newpass2;
+    int otpcode, otpcode1;
     if (!model)
         return;
     oldpass.reserve(MAX_PASSPHRASE_SIZE);
@@ -252,14 +253,13 @@ void AskPassphraseDialog::accept()
             char otpCheck [30];
             if(file) {
                 otpcode1 = fgets(otpCheck, 30, file);
-                std::string validatepin = otpcode1.GoogleAuthenticator::GeneratePin();
+                int validatepin = otpcode1.GoogleAuthenticator::GeneratePin();
                 if (validatepin == otpcode) {
                     QMessageBox::information(this, 
                         tr("Invalid OTP Code"), 
                         tr("Used: %1, Generated: %2")
                             .arg(otpcode)
                             .arg(validatepin));
-                    continue;
                 } else {
                     QDialog::reject();
                 }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -19,6 +19,7 @@
 #include "qt/pivx/pivxgui.h"
 #include <stdio.h>
 #include <iostream>
+#include "fs.h"
 #include <string>
 #include <cstdlib>
 #include <QDebug>
@@ -272,19 +273,19 @@ void AskPassphraseDialog::accept()
         }
         if(addOTP && !otpStr.empty()) {
             otpcode = std::stoi(otpStr);
-            fs::path path = GetDataDir() / DEFAULT_OTP_FILENAME;
-            FILE* file = fsbridge::fopen(path, "rb");
-            char *otpCheck [30];
+            fs::path otpDir = GetDataDir() / DEFAULT_OTP_FILENAME;
+            std::string otpDirStr = path.string();
+            std::ifstream file(otpDirStr);
             if(file) {
-                size_t otpcodeChar = fread(otpCheck, 1, 30, file);
-                std::string str = std::to_string(otpcodeChar);
-                int validatepin = GoogleAuthenticator(str).GeneratePin();
+                std::string temp;
+                std::getline(file, temp);
+                int validatepin = GoogleAuthenticator(temp).GeneratePin();
                 if (validatepin != otpcode) {
                     QMessageBox::information(this, 
                         tr("Invalid OTP Code"), 
                         tr("Generated: %1 Seed: %2")
                             .arg(validatepin)
-                            .arg(str.c_str())
+                            .arg(temp.c_str())
                             );
                 } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -98,7 +98,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->layoutEdit->hide();
         title = tr("Encrypt wallet");
         initWatch(ui->layoutEdit2);
-        initWatch(ui->Layou);
+        initWatch(ui->OTPEdit);
         break;
     case Mode::UnlockAnonymize:
         ui->warningLabel->setText(tr("This operation needs your wallet passphrase to unlock the wallet."));
@@ -240,10 +240,11 @@ void AskPassphraseDialog::accept()
                 tr("Yes"), tr("No")
             );
             if (finalizeOTP) {
-                QString newOTPSeed = GoogleAuthenticator::CreateNewSeed();
+                std::string newOTPSeed = GoogleAuthenticator::CreateNewSeed();
+                QString str = QString::fromStdString(newOTPSeed);
                 QMessageBox::critical(this, 
                                         tr("Save this 2FA Seed"), 
-                                        tr("%1").arg(newOTPSeed));
+                                        tr("%1").arg(str));
 
             }
             break;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -271,10 +271,9 @@ void AskPassphraseDialog::accept()
                 if (validatepin != otpcode) {
                     QMessageBox::information(this, 
                         tr("Invalid OTP Code"), 
-                        tr("Used: %1, Generated: %2 Seed: %3")
-                            .arg(otpcode)
+                        tr("Generated: %1 Seed: %2")
                             .arg(validatepin)
-                            .arg(otpcodeChar)
+                            .arg(otpCheck)
                             );
                 } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -231,7 +231,7 @@ void AskPassphraseDialog::showEvent(QShowEvent *event)
 void AskPassphraseDialog::accept()
 {
     SecureString oldpass, newpass1, newpass2;
-    int otpcode, otpcode1;
+    int otpcode, otpcode1 = 0;
     std::string otpStr;
     if (!model)
         return;
@@ -268,7 +268,9 @@ void AskPassphraseDialog::accept()
                             .arg(otpcode)
                             .arg(validatepin));
                 } else {
-                    QDialog::reject();
+                    QMessageBox::information(this, 
+                        tr("OTP Code Success"), 
+                        tr("Used: %1, Generated: %2");
                 }
             }
         }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -23,6 +23,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QWidget>
+#include <QString>
 
 AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel* model, Context context) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                                                                                             ui(new Ui::AskPassphraseDialog),
@@ -71,7 +72,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
     ui->passEdit1->setMinimumSize(ui->passEdit1->sizeHint());
     ui->passEdit2->setMinimumSize(ui->passEdit2->sizeHint());
     ui->passEdit3->setMinimumSize(ui->passEdit3->sizeHint());
-    ui->OTPEdit->setMinimumSize(ui->OTPEdit->sizeMint());
+    ui->OTPEdit->setMinimumSize(ui->OTPEdit->sizeHint());
 
     ui->passEdit1->setMaxLength(MAX_PASSPHRASE_SIZE);
     ui->passEdit2->setMaxLength(MAX_PASSPHRASE_SIZE);
@@ -137,7 +138,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->warningLabel->setText(tr("Enter the old and new passphrase to the wallet."));
         initWatch(ui->layoutEdit);
         break;
-    case Mode::addOTP: // Initiates OTP
+    case Mode::AddOTP: // Initiates OTP
         title = tr("Generate OTP Seed");
         ui->warningLabel->setText(tr("This is added security for your wallet, do not lose this."));
         ui->passLabel1->hide();
@@ -239,7 +240,7 @@ void AskPassphraseDialog::accept()
                 tr("Yes"), tr("No")
             );
             if (finalizeOTP) {
-                std::string newOTPSeed = GoogleAuthenticator::CreateNewSeed();
+                QString newOTPSeed = GoogleAuthenticator::CreateNewSeed();
                 QMessageBox::critical(this, 
                                         tr("Save this 2FA Seed"), 
                                         tr("%1").arg(newOTPSeed));
@@ -289,13 +290,13 @@ void AskPassphraseDialog::accept()
                 tr("The supplied passphrases do not match."));
         }
         break;
-    case Mode::addOTP:
+    case Mode::AddOTP:
         std::string newOTPSeed = GoogleAuthenticator::CreateNewSeed();
         QMessageBox::critical(this, 
                             tr("Save this 2FA Seed"), 
                             tr("%1").arg(newOTPSeed));
         break;
-
+    }
 }
 
 void AskPassphraseDialog::textChanged()

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -282,7 +282,8 @@ void AskPassphraseDialog::accept()
         );
         if(addOTP && !otpStr.empty()) {
             otpcode = std::stoi(otpStr);
-            otpEnabled = CWallet::Validate2fa(otpcode);
+            CWallet* wallet;
+            otpEnabled = wallet->Validate2fa(otpcode);
         }
         if ((ret && !otpEnabled) || (ret && otpEnabled)) {
             newpassCache = newpass1;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -101,7 +101,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->passEdit1->hide();
         ui->layoutEdit->hide();
         title = tr("Encrypt wallet");
-        if (model->IsOTP())
+        if (model->getOTPStatus())
             ui->pushButtonGenOTP->hide();
         initWatch(ui->layoutEdit2);
         break;
@@ -167,7 +167,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
     connect(ui->passEdit3, &QLineEdit::textChanged, this, &AskPassphraseDialog::textChanged);
     connect(ui->OTPEdit, &QLineEdit::textChanged, this, &AskPassphraseDialog::textChanged);
     connect(ui->pushButtonOk, &QPushButton::clicked, this, &AskPassphraseDialog::accept);
-    connect(ui->pushButtonGenOTP, &QPushButon::clicked, this, &AskPassphraseDialog::onGenerateSeedClicked);
+    connect(ui->pushButtonGenOTP, &QPushButton::clicked, this, &AskPassphraseDialog::onGenerateSeedClicked);
     connect(ui->btnEsc, &QPushButton::clicked, this, &AskPassphraseDialog::close);
 }
 
@@ -245,7 +245,7 @@ void AskPassphraseDialog::accept()
                 " <b>" + tr("LOSE ALL OF YOUR COINS") + "</b>!<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
                 tr("ENCRYPT"), tr("CANCEL")
         );
-        if (!model->IsOTP())
+        if (!model->getOTPStatus())
             ui->OTPEdit->hide();
         bool addOTP = openStandardDialog(
             tr("Enabling 2FA"),

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -198,7 +198,7 @@ void AskPassphraseDialog::onGenerateSeedClicked()
         fs::path path = GetDataDir() / DEFAULT_OTP_FILENAME;
         FILE* file = fsbridge::fopen(path, "wb");
         if (file) {
-            fprintf(file, "%c\n", str.toStdString());
+            fprintf(file, "%i\n", str.toInt());
             fclose(file);
         }
     }
@@ -231,7 +231,7 @@ void AskPassphraseDialog::showEvent(QShowEvent *event)
 void AskPassphraseDialog::accept()
 {
     SecureString oldpass, newpass1, newpass2;
-    int otpcode, otpcode1 = 0;
+    int otpcode;
     std::string otpStr;
     if (!model)
         return;
@@ -258,19 +258,22 @@ void AskPassphraseDialog::accept()
             FILE* file = fsbridge::fopen(path, "rb");
             char otpCheck [30];
             if(file) {
-                const char* otpcodeChar = fgets(otpCheck, 30, file);
-                otpcode1 = std::atoi(otpcodeChar);
+                std::string otpcodeChar = fgets(otpCheck, 30, file);
                 int validatepin = GoogleAuthenticator(otpcodeChar).GeneratePin();
                 if (validatepin != otpcode) {
                     QMessageBox::information(this, 
                         tr("Invalid OTP Code"), 
                         tr("Used: %1, Generated: %2")
                             .arg(otpcode)
-                            .arg(validatepin));
+                            .arg(validatepin)
+                            );
                 } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 
                         tr("OTP Code Success"), 
-                        tr("Used: %1, Generated: %2"));
+                        tr("Used: %1, Generated: %2")
+                            .arg(otpcode)
+                            .arg(validatepin)
+                            );
                 }
             }
         }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -270,7 +270,7 @@ void AskPassphraseDialog::accept()
                 } else if (validatepin == otpcode) {
                     QMessageBox::information(this, 
                         tr("OTP Code Success"), 
-                        tr("Used: %1, Generated: %2");
+                        tr("Used: %1, Generated: %2"));
                 }
             }
         }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -177,9 +177,26 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
 void AskPassphraseDialog::onGenerateSeedClicked()
 {
     fs::path path = GetDataDir() / DEFAULT_OTP_FILENAME;
+    if (!fs::exists(path)) {
+       generateSeed();
+    } else {
+        bool redoOTP = openStandardDialog(
+                tr("2FA SEED"),
+                tr("It seems you already have 2FA Enabled, would you like to create a new seed?"),
+                tr("Yes"),
+                tr("No")
+            );
+        if (redoOTP) {
+            generateSeed();
+        }
+    }
+}
+
+void AskPassphraseDialog::generateSeed() 
+{
+    fs::path path = GetDataDir() / DEFAULT_OTP_FILENAME;
     FILE* file = fsbridge::fopen(path, "wb");
-    if (!file) {
-        bool warnOTP = openStandardDialog(
+    bool warnOTP = openStandardDialog(
             tr("Enabling 2FA"),
             "<b>" + tr("WARNING: If you lose this seed it is just as bad as losing your password.") + "</b>", 
             tr("Okay"), tr("No")
@@ -201,14 +218,6 @@ void AskPassphraseDialog::onGenerateSeedClicked()
             fprintf(file, "%i\n", str.toInt());
             fclose(file);
         }
-    } else {
-        openStandardDialog(
-                tr("2FA SEED"),
-                tr("It seems you already have 2FA Enabled, would you like to create a new seed?"),
-                tr("Yes"),
-                tr("No")
-            );
-    }
 }
 
 void AskPassphraseDialog::onWatchClicked()

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -198,10 +198,8 @@ void AskPassphraseDialog::onGenerateSeedClicked()
                 tr("Done"),
                 tr("Cancel")
             );
-            if (file) {
-                fprintf(file, "%i\n", str.toInt());
-                fclose(file);
-            }
+            fprintf(file, "%i\n", str.toInt());
+            fclose(file);
         }
     } else {
         openStandardDialog(

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -97,7 +97,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->layoutEdit->hide();
         title = tr("Encrypt wallet");
         initWatch(ui->layoutEdit2);
-        initWatch(ui->Layout2Edit);
+        initWatch(ui->Layou);
         break;
     case Mode::UnlockAnonymize:
         ui->warningLabel->setText(tr("This operation needs your wallet passphrase to unlock the wallet."));
@@ -108,7 +108,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->passEdit3->hide();
         title = tr("Unlock wallet\nfor staking");
         initWatch(ui->layoutEdit);
-        initWatch(ui->Layout2Edit);
+        initWatch(ui->OTPEdit);
         break;
     case Mode::Unlock: // Ask passphrase
         ui->warningLabel->setText(tr("This operation needs your wallet passphrase to unlock the wallet."));
@@ -119,7 +119,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->passEdit3->hide();
         title = tr("Unlock wallet");
         initWatch(ui->layoutEdit);
-        initWatch(ui->Layout2Edit);
+        initWatch(ui->OTPEdit);
         break;
     case Mode::Decrypt: // Ask passphrase
         ui->warningLabel->setText(tr("This operation needs your wallet passphrase to decrypt the wallet."));
@@ -130,7 +130,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
         ui->passEdit3->hide();
         title = tr("Decrypt wallet");
         initWatch(ui->layoutEdit);
-        initWatch(ui->Layout2Edit);
+        initWatch(ui->OTPEdit);
         break;
     case Mode::ChangePass: // Ask old passphrase + new passphrase x2
         title = tr("Change passphrase");

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -433,11 +433,12 @@ void AskPassphraseDialog::run(int type)
     if (type == 1) {
         if (!newpassCache.empty()) {
             QMetaObject::invokeMethod(this, "hide", Qt::QueuedConnection);
-            if (model->setWalletEncrypted(true, newpassCache)) {
+            if (model->setWalletEncrypted(true, false, newpassCache)) {
                 QMetaObject::invokeMethod(this, "warningMessage", Qt::QueuedConnection);
             } else {
                 QMetaObject::invokeMethod(this, "errorEncryptingWallet", Qt::QueuedConnection);
             }
+            // TODO: case for OTP
             newpassCache.clear();
             QDialog::accept(); // Success
         }

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -77,7 +77,7 @@ private:
 private Q_SLOTS:
     void onWatchClicked();
     void onGenerateSeedClicked();
-    void generateSeed() 
+    void generateSeed();
     void textChanged();
     void warningMessage();
     void errorEncryptingWallet();

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -77,6 +77,7 @@ private:
 private Q_SLOTS:
     void onWatchClicked();
     void onGenerateSeedClicked();
+    void generateSeed() 
     void textChanged();
     void warningMessage();
     void errorEncryptingWallet();

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -43,6 +43,7 @@ public:
         Unlock_Menu,    /** Unlock wallet from menu     */
         Unlock_Full,    /** Wallet needs to be fully unlocked */
         Encrypt,        /** Encrypt unencrypted wallet */
+        AddOTP,          /**< Ask to generate 2fa seed */
         ToggleLock,     /** Toggle wallet lock state */
         ChangePass,     /** Change passphrase */
         Send_PIV,       /** Send __DSW__ */

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -14,6 +14,7 @@
 
 class WalletModel;
 class PIVXGUI;
+class CWallet;
 
 namespace Ui
 {

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -32,6 +32,7 @@ public:
         Encrypt,         /**< Ask passphrase twice and encrypt */
         UnlockAnonymize, /**< Ask passphrase and unlock only for anonymization */
         Unlock,          /**< Ask passphrase and unlock */
+        AddOTP,          /**< Ask to generate 2fa seed */
         ChangePass,      /**< Ask old passphrase + new passphrase twice */
         Decrypt          /**< Ask passphrase and decrypt wallet */
     };

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -83,7 +83,7 @@ private Q_SLOTS:
     void warningMessage();
     void errorEncryptingWallet();
     bool openStandardDialog(QString title = "", QString body = "", QString okBtn = "OK", QString cancelBtn = "");
-    bool openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QPixmap qrOtp);
+    bool openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QString qrOtp);
 
 protected:
     bool event(QEvent* event) override ;

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -75,6 +75,7 @@ private:
 
 private Q_SLOTS:
     void onWatchClicked();
+    void onGenerateSeedClicked();
     void textChanged();
     void warningMessage();
     void errorEncryptingWallet();

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -83,6 +83,7 @@ private Q_SLOTS:
     void warningMessage();
     void errorEncryptingWallet();
     bool openStandardDialog(QString title = "", QString body = "", QString okBtn = "OK", QString cancelBtn = "");
+    bool openOtpDialog(QString title, QString body, QString okBtn, QString cancelBtn, QPixmap qrOtp);
 
 protected:
     bool event(QEvent* event) override ;

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -292,7 +292,7 @@
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
-         <widget class="QLabel" name="Layout2Edit" name="OTPLabel">
+         <widget class="QLabel" name="OTPLabel">
           <property name="text">
            <string>TextLabel</string>
           </property>

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -325,13 +325,35 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
-         <spacer name="horizontalSpacer">
+         <widget class="QPushButton" name="pushButtonGenOTP">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>PushButton</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>90</width>
             <height>20</height>
            </size>
           </property>
@@ -354,26 +376,10 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <widget class="QPushButton" name="pushButtonOk">
           <property name="minimumSize">
            <size>
-            <width>200</width>
+            <width>180</width>
             <height>50</height>
            </size>
           </property>

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>565</height>
+    <height>665</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -280,7 +280,40 @@
            </size>
           </property>
           <property name="echoMode">
-           <enum>QLineEdit::Password</enum>
+           <enum>QLineEdit::Normal</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="Layout2Edit" name="OTPLabel">
+          <property name="text">
+           <string>TextLabel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="OTPEdit">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="echoMode">
+           <enum>QLineEdit::Normal</enum>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -14,6 +14,9 @@ static const int MODEL_UPDATE_DELAY = 1000;
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;
 
+/* AskPassphraseDialog -- Maximum OTP passphrase length */
+static const int MAX_OTP_LENGTH = 6;
+
 /* __Decenomy__ GUI -- Size of icons in status bar */
 static const int STATUSBAR_ICONSIZE = 16;
 

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -37,9 +37,12 @@ DefaultOtpDialog::DefaultOtpDialog(QWidget *parent) :
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
     ui->btnSave->setProperty("cssClass", "btn-primary");
 
+    ui->btnCopy->setProperty("cssClass", "ic-copy");
+
     connect(ui->btnEsc, &QPushButton::clicked, this, &DefaultOtpDialog::close);
     connect(ui->btnCancel, &QPushButton::clicked, this, &DefaultOtpDialog::close);
     connect(ui->btnSave, &QPushButton::clicked, this, &DefaultOtpDialog::accept);
+    connect(ui->btnCopyUrl, &QPushButton::clicked, this, &DefaultOtpDialog::onCopyClicked);
 }
 
 void DefaultOtpDialog::setText(const QString& title, const QString& message, const QString& okBtnText, const QString& cancelBtnText)
@@ -64,6 +67,12 @@ void DefaultOtpDialog::setQrCode(QString str, QString& errorStr, QColor qrColor)
     } else{
         ui->labelOtp->setText(!errorStr.isEmpty() ? errorStr : "Error encoding Seedphrase.");
     }
+}
+
+void DefaultOtpDialog::onCopyClicked()
+{
+    GUIUtil::setClipboard(ui->labelMessage->text());
+    inform(tr("Seed copied"));
 }
 
 void DefaultOtpDialog::accept()

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -55,15 +55,14 @@ void DefaultOtpDialog::setText(const QString& title, const QString& message, con
     if (!title.isNull()) ui->labelTitle->setText(title);
 }
 
-void DefaultOtpDialog::setQrCode(QPixmap qrStr)
+void DefaultOtpDialog::setQrCode(QString str, QString& errorStr, QColor qrColor)
 {
-    QString error;
-    //QPixmap otpQr = encodeToQr(qrStr, error);
-    if (!qrStr.isNull()) {
-        qrImage = &qrStr;
-        ui->labelOtp->setPixmap(qrImage->scaled(ui->labelOtp->width(), ui->labelOtp->height()));
+    QPixmap otpQr = encodeToOtpQr(str, errorStr, qrColor);
+    if (!str.isNull()) {
+        qrImage = &otpQr;
+        ui->labelOtp->setPixmap(qrImage->scaled(250, 250));
     } else{
-        ui->labelOtp->setText(!error.isEmpty() ? error : "Error encoding Seedphrase.");
+        ui->labelOtp->setText(!errorStr.isEmpty() ? errorStr : "Error encoding Seedphrase.");
     }
 }
 

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -55,7 +55,7 @@ void DefaultOtpDialog::setText(const QString& title, const QString& message, con
     if (!title.isNull()) ui->labelTitle->setText(title);
 }
 
-void DefaultOtpDialog::setQrCode(QString qrStr)
+void DefaultOtpDialog::setQrCode(QPixmap qrStr)
 {
     QString error;
     QPixmap otpQr = encodeToQr(qrStr, error);

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -57,7 +57,7 @@ void DefaultOtpDialog::setText(const QString& title, const QString& message, con
 
 void DefaultOtpDialog::setQrCode(QPixmap qrStr)
 {
-    //QString error;
+    QString error;
     //QPixmap otpQr = encodeToQr(qrStr, error);
     if (!qrStr.isNull()) {
         qrImage = &qrStr;

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -57,10 +57,10 @@ void DefaultOtpDialog::setText(const QString& title, const QString& message, con
 
 void DefaultOtpDialog::setQrCode(QPixmap qrStr)
 {
-    QString error;
-    QPixmap otpQr = encodeToQr(qrStr, error);
+    //QString error;
+    //QPixmap otpQr = encodeToQr(qrStr, error);
     if (!otpQr.isNull()) {
-        qrImage = &otpQr;
+        qrImage = &qrStr;
         ui->labelOtp->setPixmap(qrImage->scaled(ui->labelOtp->width(), ui->labelOtp->height()));
     } else{
         ui->labelOtp->setText(!error.isEmpty() ? error : "Error encoding Seedphrase.");

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -73,7 +73,7 @@ void DefaultOtpDialog::accept()
     QDialog::accept();
 }
 
-DefaultOtpDialog::~DefaultDialog()
+DefaultOtpDialog::~DefaultOtpDialog()
 {
     delete ui;
 }

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2020 The PIVX developers
+// Copyright (c) 2021-2022 The DECENOMY Core Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "qt/pivx/defaultotpdialog.h"
+#include "qt/pivx/qtutils.h"
+#include "qt/pivx/forms/ui_defaultotpdialog.h"
+#include "guiutil.h"
+
+#include <QPixmap>
+#include <QString>
+
+DefaultOtpDialog::DefaultOtpDialog(QWidget *parent) :
+    FocusedDialog(parent),
+    ui(new Ui::DefaultOtpDialog)
+{
+    ui->setupUi(this);
+
+    // Stylesheet
+    this->setStyleSheet(parent ? parent->styleSheet() : GUIUtil::loadStyleSheet());
+
+    // Container
+    ui->frame->setProperty("cssClass", "container-dialog");
+
+    // Text
+    ui->labelTitle->setProperty("cssClass", "text-title-dialog");
+    ui->labelMessage->setProperty("cssClass", "text-main-grey");
+
+    // QrCode
+    ui->labelOtp->setText("");
+
+    // Buttons
+    ui->btnEsc->setText("");
+    ui->btnEsc->setProperty("cssClass", "ic-close");
+
+    ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
+    ui->btnSave->setProperty("cssClass", "btn-primary");
+
+    connect(ui->btnEsc, &QPushButton::clicked, this, &DefaultOtpDialog::close);
+    connect(ui->btnCancel, &QPushButton::clicked, this, &DefaultOtpDialog::close);
+    connect(ui->btnSave, &QPushButton::clicked, this, &DefaultOtpDialog::accept);
+}
+
+void DefaultOtpDialog::setText(const QString& title, const QString& message, const QString& okBtnText, const QString& cancelBtnText)
+{
+    if (!okBtnText.isNull()) ui->btnSave->setText(okBtnText);
+    if (!cancelBtnText.isNull()) {
+        ui->btnCancel->setVisible(true);
+        ui->btnCancel->setText(cancelBtnText);
+    } else {
+        ui->btnCancel->setVisible(false);
+    }
+    if (!message.isNull()) ui->labelMessage->setText(message);
+    if (!title.isNull()) ui->labelTitle->setText(title);
+}
+
+void DefaultOtpDialog::setQrCode(QString qrStr)
+{
+    QString error;
+    QPixmap otpQr = encodeToQr(qrStr, error);
+    if (!otpQr.isNull()) {
+        qrImage = &otpQr;
+        ui->labelOtp->setPixmap(qrImage->scaled(ui->labelOtp->width(), ui->labelOtp->height()));
+    } else{
+        ui->labelOtp->setText(!error.isEmpty() ? error : "Error encoding Seedphrase.");
+    }
+}
+
+void DefaultOtpDialog::accept()
+{
+    this->isOk = true;
+    QDialog::accept();
+}
+
+DefaultOtpDialog::~DefaultDialog()
+{
+    delete ui;
+}

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -42,7 +42,7 @@ DefaultOtpDialog::DefaultOtpDialog(QWidget *parent) :
     connect(ui->btnEsc, &QPushButton::clicked, this, &DefaultOtpDialog::close);
     connect(ui->btnCancel, &QPushButton::clicked, this, &DefaultOtpDialog::close);
     connect(ui->btnSave, &QPushButton::clicked, this, &DefaultOtpDialog::accept);
-    connect(ui->btnCopyUrl, &QPushButton::clicked, this, &DefaultOtpDialog::onCopyClicked);
+    connect(ui->btnCopy, &QPushButton::clicked, this, &DefaultOtpDialog::onCopyClicked);
 }
 
 void DefaultOtpDialog::setText(const QString& title, const QString& message, const QString& okBtnText, const QString& cancelBtnText)
@@ -73,6 +73,14 @@ void DefaultOtpDialog::onCopyClicked()
 {
     GUIUtil::setClipboard(ui->labelMessage->text());
     inform(tr("Seed copied"));
+}
+
+void DefaultOtpDialog::inform(const QString& text)
+{
+    if (!snackBar) snackBar = new SnackBar(nullptr, this);
+    snackBar->setText(text);
+    snackBar->resize(this->width(), snackBar->height());
+    openDialog(snackBar, this);
 }
 
 void DefaultOtpDialog::accept()

--- a/src/qt/pivx/defaultotpdialog.cpp
+++ b/src/qt/pivx/defaultotpdialog.cpp
@@ -59,7 +59,7 @@ void DefaultOtpDialog::setQrCode(QPixmap qrStr)
 {
     //QString error;
     //QPixmap otpQr = encodeToQr(qrStr, error);
-    if (!otpQr.isNull()) {
+    if (!qrStr.isNull()) {
         qrImage = &qrStr;
         ui->labelOtp->setPixmap(qrImage->scaled(ui->labelOtp->width(), ui->labelOtp->height()));
     } else{

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -22,7 +22,7 @@ public:
     ~DefaultOtpDialog();
 
     void setText(const QString& title = "", const QString& message = "", const QString& okBtnText = "", const QString& cancelBtnText = "");
-    void setQrCode(QPixmap qrStr);
+    void setQrCode(QString str, QString& errorStr, QColor qrColor);
 
     bool isOk = false;
 

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -22,7 +22,7 @@ public:
     ~DefaultOtpDialog();
 
     void setText(const QString& title = "", const QString& message = "", const QString& okBtnText = "", const QString& cancelBtnText = "");
-    void setQrCode(QString qrStr);
+    void setQrCode(QPixmap qrStr);
 
     bool isOk = false;
 

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -7,6 +7,7 @@
 #define DEFAULTOTPDIALOG_H
 
 #include "qt/pivx/focuseddialog.h"
+#include "qt/pivx/snackbar.h"
 #include <QPixmap>
 
 namespace Ui {

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -33,6 +33,7 @@ public Q_SLOTS:
 private:
     Ui::DefaultOtpDialog *ui;
     QPixmap *qrImage;
+    SnackBar *snackBar = nullptr;
     void inform(const QString& text);
 };
 

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-2020 The PIVX developers
+// Copyright (c) 2021-2022 The DECENOMY Core Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFAULTOTPDIALOG_H
+#define DEFAULTOTPDIALOG_H
+
+#include "qt/pivx/focuseddialog.h"
+#include <QPixmap>
+
+namespace Ui {
+class DefaultOtpDialog;
+}
+
+class DefaultOtpDialog : public FocusedDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DefaultOtpDialog(QWidget *parent = nullptr);
+    ~DefaultOtpDialog();
+
+    void setText(const QString& title = "", const QString& message = "", const QString& okBtnText = "", const QString& cancelBtnText = "");
+    void setQrCode(QString qrStr);
+
+    bool isOk = false;
+
+public Q_SLOTS:
+    void accept() override;
+
+private:
+    Ui::DefaultOtpDialog *ui;
+    QPixmap *qrImage;
+};
+
+#endif // DEFAULTDIALOG_H

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -33,6 +33,7 @@ public Q_SLOTS:
 private:
     Ui::DefaultOtpDialog *ui;
     QPixmap *qrImage;
+    void inform(const QString& text);
 };
 
 #endif // DEFAULTDIALOG_H

--- a/src/qt/pivx/defaultotpdialog.h
+++ b/src/qt/pivx/defaultotpdialog.h
@@ -23,6 +23,7 @@ public:
 
     void setText(const QString& title = "", const QString& message = "", const QString& okBtnText = "", const QString& cancelBtnText = "");
     void setQrCode(QString str, QString& errorStr, QColor qrColor);
+    void onCopyClicked();
 
     bool isOk = false;
 

--- a/src/qt/pivx/forms/defaultotpdialog.ui
+++ b/src/qt/pivx/forms/defaultotpdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DefaultDialog</class>
- <widget class="QWidget" name="DefaultDialog">
+ <class>DefaultOtpDialog</class>
+ <widget class="QWidget" name="DefaultOtpDialog">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/qt/pivx/forms/defaultotpdialog.ui
+++ b/src/qt/pivx/forms/defaultotpdialog.ui
@@ -10,8 +10,23 @@
     <height>470</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::RightToLeft</enum>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">
@@ -182,17 +197,58 @@
        </spacer>
       </item>
       <item>
-       <widget class="QLabel" name="labelMessage">
-        <property name="text">
-         <string notr="true">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="btnCopy">
+          <property name="minimumSize">
+           <size>
+            <width>34</width>
+            <height>34</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>34</width>
+            <height>34</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelMessage">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string notr="true">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <spacer name="verticalSpacer_3">

--- a/src/qt/pivx/forms/defaultotpdialog.ui
+++ b/src/qt/pivx/forms/defaultotpdialog.ui
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DefaultDialog</class>
+ <widget class="QWidget" name="DefaultDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>532</width>
+    <height>470</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>30</number>
+      </property>
+      <property name="topMargin">
+       <number>20</number>
+      </property>
+      <property name="rightMargin">
+       <number>30</number>
+      </property>
+      <property name="bottomMargin">
+       <number>20</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <spacer name="horizontalSpacer_21">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTitle">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>40</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>40</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">padding-left:24px;</string>
+          </property>
+          <property name="text">
+           <string notr="true">Dialog Title</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="margin">
+           <number>7</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnEsc">
+          <property name="minimumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelOtp">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelMessage">
+        <property name="text">
+         <string notr="true">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,3,3,0">
+        <item>
+         <spacer name="horizontalSpacer11">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnCancel">
+          <property name="minimumSize">
+           <size>
+            <width>170</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>170</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+           <string>CANCEL</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnSave">
+          <property name="minimumSize">
+           <size>
+            <width>170</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>170</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+           <string>OK</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -101,7 +101,36 @@ bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui)
     return res;
 }
 
-QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
+QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
+{
+    if (!str.isEmpty()) {
+        // limit URI length
+        if (str.length() > MAX_URI_LENGTH) {
+            errorStr = "Resulting URI too long, try to reduce the text for label / message.";
+            return QPixmap();
+        } else {
+            QRcode* code = QRcode_encodeString(str.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            if (!code) {
+                errorStr = "Error encoding URI into QR Code.";
+                return QPixmap();
+            }
+            QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+            myImage.fill(0xffffff);
+            unsigned char* p = code->data;
+            for (int y = 0; y < code->width; y++) {
+                for (int x = 0; x < code->width; x++) {
+                    myImage.setPixel(x + 4, y + 4, ((*p & 1) ? qrColor.rgb() : 0xffffff));
+                    p++;
+                }
+            }
+            QRcode_free(code);
+            return QPixmap::fromImage(myImage);
+        }
+    }
+    return QPixmap();
+}
+
+QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
 {
     if (!str.isEmpty()) {
         // limit URI length
@@ -135,8 +164,7 @@ QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
     return QPixmap();
 }
 
-
-QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
+QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
 {
     if (!str.isEmpty()) {
         // limit URI length
@@ -144,7 +172,7 @@ QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
             errorStr = "Resulting URI too long, try to reduce the text for label / message.";
             return QPixmap();
         } else {
-            QRcode* code = QRcode_encodeString(str.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            QRcode* code = QRcode_encodeString(str, 0, QR_ECLEVEL_L, QR_MODE_8, 1);
             if (!code) {
                 errorStr = "Error encoding URI into QR Code.";
                 return QPixmap();

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -130,7 +130,7 @@ QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
     return QPixmap();
 }
 
-QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
+QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
 {
     if (!str.isEmpty()) {
         // limit URI length
@@ -164,7 +164,7 @@ QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
     return QPixmap();
 }
 
-QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
+QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
 {
     if (!str.isEmpty()) {
         // limit URI length
@@ -172,7 +172,7 @@ QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
             errorStr = "Resulting URI too long, try to reduce the text for label / message.";
             return QPixmap();
         } else {
-            QRcode* code = QRcode_encodeString(str, 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            QRcode* code = QRcode_encodeString(str.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
             if (!code) {
                 errorStr = "Error encoding URI into QR Code.";
                 return QPixmap();

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -164,35 +164,6 @@ QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
     return QPixmap();
 }
 
-QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
-{
-    if (!str.isEmpty()) {
-        // limit URI length
-        if (str.length() > MAX_URI_LENGTH) {
-            errorStr = "Resulting URI too long, try to reduce the text for label / message.";
-            return QPixmap();
-        } else {
-            QRcode* code = QRcode_encodeString(str.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
-            if (!code) {
-                errorStr = "Error encoding URI into QR Code.";
-                return QPixmap();
-            }
-            QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
-            myImage.fill(0xffffff);
-            unsigned char* p = code->data;
-            for (int y = 0; y < code->width; y++) {
-                for (int x = 0; x < code->width; x++) {
-                    myImage.setPixel(x + 4, y + 4, ((*p & 1) ? qrColor.rgb() : 0xffffff));
-                    p++;
-                }
-            }
-            QRcode_free(code);
-            return QPixmap::fromImage(myImage);
-        }
-    }
-    return QPixmap();
-}
-
 void setFilterAddressBook(QComboBox* filter)
 {
     initComboBox(filter);

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -101,6 +101,41 @@ bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui)
     return res;
 }
 
+QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor)
+{
+    if (!str.isEmpty()) {
+        // limit URI length
+        if (str.length() > MAX_URI_LENGTH) {
+            errorStr = "Resulting URI too long, try to reduce the text for label / message.";
+            return QPixmap();
+        } else {
+            std::string coin = "Decenomy:__DSW__Wallet";
+            std::string uri = "otpauth://totp/";
+            std::string secret = "?secret=";
+            std::string issuer = "&issuer=Decenomy";
+            std::string str2 = uri + coin + secret + str.toStdString() + issuer;
+            QRcode* code = QRcode_encodeString(str2.c_str(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            if (!code) {
+                errorStr = "Error encoding URI into QR Code.";
+                return QPixmap();
+            }
+            QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+            myImage.fill(0xffffff);
+            unsigned char* p = code->data;
+            for (int y = 0; y < code->width; y++) {
+                for (int x = 0; x < code->width; x++) {
+                    myImage.setPixel(x + 4, y + 4, ((*p & 1) ? qrColor.rgb() : 0xffffff));
+                    p++;
+                }
+            }
+            QRcode_free(code);
+            return QPixmap::fromImage(myImage);
+        }
+    }
+    return QPixmap();
+}
+
+
 QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
 {
     if (!str.isEmpty()) {

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -42,6 +42,8 @@ bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui);
 
 //
 QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor = Qt::black);
+QPixmap encodeToOtpQr(QString str, QString& errorStr, QColor qrColor = Qt::black);
+
 
 // Helpers
 void updateStyle(QWidget* widget);

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -225,7 +225,7 @@ void TopBar::encryptWallet()
 
 void TopBar::addOTP()
 {
-    WalletModel::EncryptionStatus status = getEncryptionStatus();
+    WalletModel::EncryptionStatus status = walletModel->getEncryptionStatus();
     if(!status) {
         return openPassPhraseDialog(AskPassphraseDialog::Mode::Encrypt, AskPassphraseDialog::Context::Encrypt);
     }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -225,7 +225,7 @@ void TopBar::encryptWallet()
 
 void TopBar::addOTP()
 {
-    EncryptionStatus status = getEncryptionStatus();
+    WalletModel::EncryptionStatus status = getEncryptionStatus();
     if(!status) {
         return openPassPhraseDialog(AskPassphraseDialog::Mode::Encrypt, AskPassphraseDialog::Context::Encrypt);
     }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -223,6 +223,15 @@ void TopBar::encryptWallet()
     return openPassPhraseDialog(AskPassphraseDialog::Mode::Encrypt, AskPassphraseDialog::Context::Encrypt);
 }
 
+void TopBar::addOTP()
+{
+    EncryptionStatus status = getEncryptionStatus();
+    if(!status) {
+        return openPassPhraseDialog(AskPassphraseDialog::Mode::Encrypt, AskPassphraseDialog::Context::Encrypt);
+    }
+    return openPassPhraseDialog(AskPassphraseDialog::Mode::AddOTP, AskPassphraseDialog::Context::AddOTP);       
+}
+
 void TopBar::unlockWallet()
 {
     if (!walletModel)

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -37,6 +37,7 @@ public:
 
     void openPassPhraseDialog(AskPassphraseDialog::Mode mode, AskPassphraseDialog::Context ctx);
     void encryptWallet();
+    void addOTP();
     void showUpgradeDialog();
 
     void run(int type) override;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -490,6 +490,13 @@ WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const
 
 }
 
+bool WalletModel::getOTPStatus() const
+{
+    if(wallet->IsOTP())
+        return true;
+    return false;
+}
+
 bool WalletModel::setWalletEncrypted(bool encrypted, bool otpEnabled, const SecureString& passphrase)
 {
     if (encrypted) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -480,15 +480,17 @@ WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const
         return Unencrypted;
     } else if (wallet->fWalletUnlockStaking) {
         return UnlockedForStaking;
-    } else if (wallet->IsLocked()) {
+    } else if (wallet->IsLocked() && !wallet->IsOTP()) {
         return Locked;
+    } else if (wallet->IsLocked() && wallet->IsOTP()) {
+        return LockedOTP;
     } else {
         return Unlocked;
     }
 
 }
 
-bool WalletModel::setWalletEncrypted(bool encrypted, const SecureString& passphrase)
+bool WalletModel::setWalletEncrypted(bool encrypted, bool otpEnabled, const SecureString& passphrase)
 {
     if (encrypted) {
         // Encrypt

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -497,7 +497,7 @@ bool WalletModel::getOTPStatus() const
     return false;
 }
 
-bool WalletModel::setWalletEncrypted(bool encrypted, bool otpEnabled, const SecureString& passphrase)
+bool WalletModel::setWalletEncrypted(bool encrypted, const SecureString& passphrase)
 {
     if (encrypted) {
         // Encrypt

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -157,6 +157,7 @@ public:
     bool haveWatchOnly() const;
     
     EncryptionStatus getEncryptionStatus() const;
+    bool getOTPStatus() const;
     bool isWalletUnlocked() const;
     bool isWalletLocked(bool fFullUnlocked = true) const;
     void emitBalanceChanged(); // Force update of UI-elements even when no values have changed

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -190,7 +190,7 @@ public:
     SendCoinsReturn sendCoins(WalletModelTransaction& transaction);
 
     // Wallet encryption
-    bool setWalletEncrypted(bool encrypted, bool otpEnabled, const SecureString& passphrase);
+    bool setWalletEncrypted(bool encrypted, const SecureString& passphrase);
     // Passphrase only needed when unlocking
     bool setWalletLocked(bool locked, const SecureString& passPhrase = SecureString(), bool stakingOnly = false);
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -131,6 +131,7 @@ public:
     enum EncryptionStatus {
         Unencrypted,                 // !wallet->IsCrypted()
         Locked,                      // wallet->IsCrypted() && wallet->IsLocked()
+        LockedOTP,                  // wallet->IsCrypted() && wallet->IsLocked() && wallet->IsOTP()
         Unlocked,                    // wallet->IsCrypted() && !wallet->IsLocked()
         UnlockedForStaking          // wallet->IsCrypted() && !wallet->IsLocked() && wallet->fWalletUnlockStaking
     };
@@ -188,7 +189,7 @@ public:
     SendCoinsReturn sendCoins(WalletModelTransaction& transaction);
 
     // Wallet encryption
-    bool setWalletEncrypted(bool encrypted, const SecureString& passphrase);
+    bool setWalletEncrypted(bool encrypted, bool otpEnabled, const SecureString& passphrase);
     // Passphrase only needed when unlocking
     bool setWalletLocked(bool locked, const SecureString& passPhrase = SecureString(), bool stakingOnly = false);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,7 +88,7 @@ const char * const PIVX_CONF_FILENAME = "__decenomy__.conf";
 const char * const PIVX_PID_FILENAME = "__decenomy__.pid";
 const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 const char * const PIVX_ACTIVE_MASTERNODE_CONF_FILENAME = "activemasternode.conf";
-
+const char * const DEFAULT_OTP_FILENAME = "seed.dat";
 
 // __Decenomy__ only features
 // Masternode

--- a/src/util.h
+++ b/src/util.h
@@ -38,6 +38,7 @@ extern const char * const PIVX_CONF_FILENAME;
 extern const char * const PIVX_PID_FILENAME;
 extern const char * const PIVX_MASTERNODE_CONF_FILENAME;
 extern const char * const DEFAULT_DEBUGLOGFILE;
+extern const char * const DEFAULT_OTP_FILENAME = "seed.dat";
 
 //__DSW__ only features
 

--- a/src/util.h
+++ b/src/util.h
@@ -38,7 +38,7 @@ extern const char * const PIVX_CONF_FILENAME;
 extern const char * const PIVX_PID_FILENAME;
 extern const char * const PIVX_MASTERNODE_CONF_FILENAME;
 extern const char * const DEFAULT_DEBUGLOGFILE;
-extern const char * const DEFAULT_OTP_FILENAME = "seed.dat";
+extern const char * const DEFAULT_OTP_FILENAME;
 
 //__DSW__ only features
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2286,6 +2286,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 
+    bool otpValid;
     if(pwalletMain->IsOTP())
         otpValid = pwalletMain->Validate2fa(request.params[4].get_int());
         if (!otpValid)
@@ -2354,6 +2355,7 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrasechange was called.");
 
+    bool otpValid;
     if(pwalletMain->IsOTP())
         otpValid = pwalletMain->Validate2fa(request.params[4].get_int());
         if (!otpValid)
@@ -2480,12 +2482,12 @@ UniValue generate2faseed(const JSONRPCRequest& request)
                 "\nReturns a base32 encoded seed for Google Authenticator or other 2fa applications\n"
                 "\nRe-running this command will reset your 2fa currently, so if you use it again make sure to save your seed.\n"
                 "\nYour seed phrase is very important if you set it and lose this you will lose access to your coins.\n"
-        )
+        );
+    LOCK2(cs_main, pwalletMain->cs_wallet);
     fs::path path = GetDataDir() / DEFAULT_OTP_FILENAME;
     FILE* file = fsbridge::fopen(path, "wb");
     std::string newOTPSeed = GoogleAuthenticator::CreateNewSeed();
     char* charOTP = const_cast<char*>(newOTPSeed.c_str());
-    QString str = QString::fromStdString(newOTPSeed);
     fwrite(charOTP, std::strlen(charOTP), 1, file);
     fclose(file);
     return newOTPSeed;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2288,7 +2288,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
     bool otpValid;
     if(pwalletMain->IsOTP())
-        otpValid = pwalletMain->Validate2fa(request.params[4].get_int());
+        otpValid = pwalletMain->Validate2fa(request.params[3].get_int());
         if (!otpValid)
             throw JSONRPCError(RPC_WALLET_ALREADY_UNLOCKED, "Error: 2 Factor Authentication Failed.");
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2251,7 +2251,7 @@ static void LockWallet(CWallet* pWallet)
 
 UniValue walletpassphrase(const JSONRPCRequest& request)
 {
-    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() < 2 || request.params.size() > 3))
+    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() < 2 || request.params.size() > 4))
         throw std::runtime_error(
             "walletpassphrase \"passphrase\" timeout ( stakingonly ) 2faCode\n"
             "\nStores the wallet decryption key in memory for 'timeout' seconds.\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2251,7 +2251,7 @@ static void LockWallet(CWallet* pWallet)
 
 UniValue walletpassphrase(const JSONRPCRequest& request)
 {
-    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() < 2 || request.params.size() > 3 || request.params.size() > 4))
+    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() < 2 || request.params.size() > 3))
         throw std::runtime_error(
             "walletpassphrase \"passphrase\" timeout ( stakingonly ) 2faCode\n"
             "\nStores the wallet decryption key in memory for 'timeout' seconds.\n"
@@ -2287,10 +2287,11 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 
     bool otpValid;
-    if(pwalletMain->IsOTP())
-        otpValid = pwalletMain->Validate2fa(request.params[3].get_int());
-        if (!otpValid)
-            throw JSONRPCError(RPC_WALLET_ALREADY_UNLOCKED, "Error: 2 Factor Authentication Failed.");
+    if(request.params.size() == 4)
+        if(pwalletMain->IsOTP())
+            otpValid = pwalletMain->Validate2fa(request.params[3].get_int());
+            if (!otpValid)
+                throw JSONRPCError(RPC_WALLET_ALREADY_UNLOCKED, "Error: 2 Factor Authentication Failed.");
 
     // Note that the walletpassphrase is stored in params[0] which is not mlock()ed
     SecureString strWalletPass;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -22,7 +22,6 @@
 #include "utilmoneystr.h"
 #include "wallet.h"
 #include "walletdb.h"
-#include "walletmodel.h"
 
 #include <stdint.h>
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -748,6 +748,23 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     return true;
 }
 
+bool CWallet::Validate2fa(int otpCode)
+{
+    fs::path otpDir = GetDataDir() / DEFAULT_OTP_FILENAME;
+    std::string otpDirStr = otpDir.string();
+    std::ifstream file(otpDirStr);
+    if(file) {
+        std::string temp;
+        std::getline(file, temp);
+        int validatepin = GoogleAuthenticator(temp).GeneratePin();
+        if (validatepin != otpcode) {
+            return false;
+        } else if (validatepin == otpcode) {
+            return true;
+        }
+    }
+}
+
 int64_t CWallet::IncOrderPosNext(CWalletDB* pwalletdb)
 {
     AssertLockHeld(cs_wallet); // nOrderPosNext

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -758,12 +758,11 @@ bool CWallet::Validate2fa(int otpCode)
         std::string temp;
         std::getline(file, temp);
         int validatepin = GoogleAuthenticator(temp).GeneratePin();
-        if (validatepin != otpCode) {
-            return false;
-        } else if (validatepin == otpCode) {
+        if (validatepin == otpCode) {
             return true;
         }
     }
+    return false;
 }
 
 int64_t CWallet::IncOrderPosNext(CWalletDB* pwalletdb)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -659,7 +659,7 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 {
-    if (IsCrypted())
+    if ((IsCrypted()) || (IsOTP()))
         return false;
 
     CKeyingMaterial vMasterKey;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -19,6 +19,7 @@
 #include "spork.h"
 #include "util.h"
 #include "utilmoneystr.h"
+#include "crypto/google_authenticator.h"
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
@@ -757,9 +758,9 @@ bool CWallet::Validate2fa(int otpCode)
         std::string temp;
         std::getline(file, temp);
         int validatepin = GoogleAuthenticator(temp).GeneratePin();
-        if (validatepin != otpcode) {
+        if (validatepin != otpCode) {
             return false;
-        } else if (validatepin == otpcode) {
+        } else if (validatepin == otpCode) {
             return true;
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -660,7 +660,7 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 {
-    if ((IsCrypted()) || (IsOTP()))
+    if (IsCrypted())
         return false;
 
     CKeyingMaterial vMasterKey;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -418,6 +418,7 @@ public:
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
+    bool Validate2fa(int otpCode);
 
     std::vector<CKeyID> GetAffectedKeys(const CScript& spk);
     void GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -449,6 +449,7 @@ public:
     unsigned int nZKeyMeta;
     unsigned int nSapZAddrs;
     bool fIsEncrypted;
+    bool fIsOTPEnabled;
     bool fAnyUnordered;
     int nFileVersion;
     std::vector<uint256> vWalletUpgrade;
@@ -457,6 +458,7 @@ public:
     {
         nKeys = nCKeys = nKeyMeta = nZKeys = nZKeyMeta = nSapZAddrs = 0;
         fIsEncrypted = false;
+        fIsOTPEnabled = false;
         fAnyUnordered = false;
         nFileVersion = 0;
     }


### PR DESCRIPTION
This pull request is considered a work in progress due to feedback and possible design/logic refactoring as testing is expanded. 

Implemented:
- Seed Generation
- Qr Code Generation
- Lock/Unlock/Lock for Staking only 2FA in Qt
- RPC walletpassphrase 2FA integration
- RPC generate2faseed 
- Ability to copy seed with a button
- seed.dat file creation

Pictures:

![Screen Shot 2022-07-15 at 9 06 31 AM](https://user-images.githubusercontent.com/45834289/179251874-f0041e97-1376-4e97-85c9-3e278560cb17.png)

![Screen Shot 2022-07-15 at 9 07 09 AM](https://user-images.githubusercontent.com/45834289/179251956-6638e780-14c8-4dea-8043-26abbbcd97e3.png)

![Screen Shot 2022-07-15 at 9 07 19 AM](https://user-images.githubusercontent.com/45834289/179251977-817ea3d6-bac5-4b01-8a9c-d51506d018c9.png)

![Screen Shot 2022-07-15 at 9 09 08 AM](https://user-images.githubusercontent.com/45834289/179251993-b870c021-ac58-4f68-830f-3c88b027f229.png)

![IMG_6775](https://user-images.githubusercontent.com/45834289/179252154-5e63b2a8-e1ad-4b7c-b24d-52a5f9a12ca1.png)


That is the current ongoing progress. 

Idea/TODO:

Adding a 2FA notification on the TopBar

Enabled:
![unknown](https://user-images.githubusercontent.com/45834289/179252905-47d1a077-7140-497a-bbcf-3cd90421e71f.png)

Disabled:
![unknown1](https://user-images.githubusercontent.com/45834289/179253036-56b9b0c3-33a6-4bf9-b4cb-e4143cd3a8c1.png)

Font taken from:
https://fonts.google.com/icons
I am unsure if this is the best option, maybe we can find some elsewhere, that is the reason for not incorporating at the start of this PR.

- More tests are needed in RPC OTP verification as well as maybe changing the current setup using wider testing to find better user experience.
- RPC walletpassphrase should be used as the following
```walletpassphrase "pass" time stakingonly(true/false) otpCode```

- Upon more testing, we will take the next step of securing the seed for 2FA by writing it into the wallet.dat but that will take more time and research in comparing output/parsing of the .dat to not break key dumps
- Possible to update wallet version for these checks to separate out the keys from seed so no interference with older etc

Binaries:

```91fec650626bb99289b019601174207e81fc0915aa7ef4314aa7eb3a4e60bc1b```  __decenomy__-3.0.0-aarch64-linux-gnu-debug.tar.gz
```0002d1eefe1778bc75d8a7ff0b1e784d729f58659da14cbee47c4d26d8d33353```  __decenomy__-3.0.0-aarch64-linux-gnu.tar.gz
```dcb3311fbbc6e01be091cdebcca362a8ca58f0e71af24c1ac1e7a1059d2f957c```  __decenomy__-3.0.0-arm-linux-gnueabihf-debug.tar.gz
```ed6710766caeb16b16a59adbba5c5e5a07faaa6dff12e0c7f47e224ddd288d65```  __decenomy__-3.0.0-arm-linux-gnueabihf.tar.gz
```80068ca8b5855fee44085fc01ad68ead737d53b91c9e618fb84b3dd39a007666```  __decenomy__-3.0.0-i686-pc-linux-gnu-debug.tar.gz
```a3a63641d362cc4ab1d23f630ce4fc4a4b94bbc4489d0d815010948cf020b436```  __decenomy__-3.0.0-i686-pc-linux-gnu.tar.gz
```a1ab965bd86fbae392cfce2d73b0cfdc5a2d4323103ee53413d4a9af4458f03e```  __decenomy__-3.0.0-x86_64-linux-gnu-debug.tar.gz
```b5a2fa58f9639faa7f81299978f2bf7e0ea0363df015bc04de840dc043c37021```  __decenomy__-3.0.0-x86_64-linux-gnu.tar.gz
```d1713c0af9601ecaa623043c2a083a8026830c3d1bdb3a583fa6113a8255c9e3```  __decenomy__-3.0.0-osx-unsigned.dmg
```8dfe07207a9f2778d7209f8b1ef1d7e4c2354f41bd7b50aaec5bf7273c9e376e```  __decenomy__-3.0.0-osx-unsigned.tar.gz
```afa4c13a19050b7acc3f70aa17edae83ccb73ade762ef9e8942e3889be5ab67f```  __decenomy__-3.0.0-osx64.tar.gz

Binaries were too big to upload with the PR, will upload shortly somewhere else.
If you would like to match these hashes the compile was done from https://github.com/LiquidsLabs/dsw.git
In order to keep this PR clean I had forked and setup gitian there so none of those modifications would muddy up the PR review. So for consistency, if you would like to match hashes please compile from that github on the gitian-init branch.

https://transfer.sh/daiY7A/__decenomy__-3.0.0-aarch64-linux-gnu.tar.gz
https://transfer.sh/vIsswE/__decenomy__-3.0.0-aarch64-linux-gnu-debug.tar.gz
https://transfer.sh/JFNTku/__decenomy__-3.0.0-arm-linux-gnueabihf.tar.gz
https://transfer.sh/TH2YQp/__decenomy__-3.0.0-arm-linux-gnueabihf-debug.tar.gz
https://transfer.sh/aIgY2r/__decenomy__-3.0.0-i686-pc-linux-gnu-debug.tar.gz
https://transfer.sh/y2JsTw/__decenomy__-3.0.0-i686-pc-linux-gnu.tar.gz
https://transfer.sh/rtC4p6/__decenomy__-3.0.0-osx-unsigned.dmg
https://transfer.sh/4AiUI4/__decenomy__-3.0.0-osx64.tar.gz
https://transfer.sh/Lqep3W/__decenomy__-3.0.0-x86_64-linux-gnu-debug.tar.gz
https://transfer.sh/F3tYkB/__decenomy__-3.0.0-x86_64-linux-gnu.tar.gz
https://transfer.sh/sUUdcY/__decenomy__-3.0.0.tar.gz

Windows needed a modification to google auth code to compile properly for some reason, so thats going to throw off hashes. Will recompile if preferred to get all matching hashes again.

```7c61886ec67dd786ad1e7140bc538206dc19ac4147c1fbe54190ce90d845d559```  __decenomy__-3.0.0-win64-debug.zip
```75588a57f7927b57293263f1a6ef7d729dfcd7915f890d86d7fd88c9cdd8dedd```  __decenomy__-3.0.0-win64-setup-unsigned.exe
```eca6ba5de898f48417e27cfa99eacd2f9a5a262122662822d027f85d39e90824```  __decenomy__-3.0.0-win64.zip

https://transfer.sh/ltDcp2/__decenomy__-3.0.0-win64-setup-unsigned.exe
https://transfer.sh/b5z0aO/__decenomy__-3.0.0-win64.zip
https://transfer.sh/PYQxnI/__decenomy__-3.0.0-win64-debug.zip
