### PR TITLE
Fix compilation with newer GCC branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,9 @@
 *.sublime-workspace
 todo.txt
 reset-files.bash
-
 *.tar.gz
-
 *.exe
+configure~
 
 # DSW
 src/__decenomy__

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -8,7 +8,7 @@ fi
 
 # Upgrade the system and install required dependencies
 	sudo apt update
-	sudo apt install git zip unzip build-essential libtool bsdmainutils autotools-dev autoconf pkg-config automake python3 curl g++-mingw-w64-x86-64 libqt5svg5-dev -y
+	sudo apt install git zip unzip build-essential libtool bsdmainutils autotools-dev autoconf pkg-config automake python3 curl g++-mingw-w64-x86-64 g++-mingw-w64-x86-64-posix libqt5svg5-dev -y
 	echo "1" | sudo update-alternatives --config x86_64-w64-mingw32-g++
 
 # Clone code from official Github repository
@@ -18,8 +18,11 @@ fi
 # Entering directory
 	cd DSW
 
+# Disable WSL support for Win32 applications.
+sudo bash -c "echo 0 > /proc/sys/fs/binfmt_misc/status"
+
 # Compile dependencies
-	cd depends
+	cd depends 
 	make -j$(echo $CPU_CORES) HOST=x86_64-w64-mingw32 
 	cd ..
 
@@ -33,3 +36,6 @@ fi
 	cp DSW/src/__decenomy__d.exe DSW/src/__decenomy__-cli.exe DSW/src/__decenomy__-tx.exe DSW/src/qt/__decenomy__-qt.exe .
 	zip __DSW__-Windows.zip __decenomy__d.exe __decenomy__-cli.exe __decenomy__-tx.exe __decenomy__-qt.exe
 	rm -f __decenomy__d.exe __decenomy__-cli.exe __decenomy__-tx.exe __decenomy__-qt.exe
+
+# Enable WSL support for Win32 applications.
+sudo bash -c "echo 1 > /proc/sys/fs/binfmt_misc/status"

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,6 +4,7 @@ $(package)_version=1_71_0
 $(package)_download_path=https://github.com/decenomy/depends/raw/main/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
+$(package)_patches=fix_gcc_11_3_compile.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -30,7 +31,8 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
+  patch -p1 -i $($(package)_patch_dir)/fix_gcc_11_3_compile.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,9 +1,9 @@
 package=libevent
-$(package)_version=2.1.8-stable
-#$(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_download_path=https://github.com/decenomy/depends/raw/main/
-$(package)_file_name=release-$($(package)_version).tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_version=2.1.12-stable
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/
+#$(package)_download_path=https://github.com/decenomy/depends/raw/main/
+$(package)_file_name=libevent-$($(package)_version).tar.gz
+$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
 define $(package)_preprocess_cmds
   ./autogen.sh

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -9,7 +9,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib concurrent
-$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch fix_s390x_powerpc_mips_mipsel_architectures.patch xkb-default.patch
+$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch fix_s390x_powerpc_mips_mipsel_architectures.patch xkb-default.patch fix_gcc_11_3_compile.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=f7474f260a1382549720081bf2359a3d425ec3bf7d31976c512834303d30d73b
@@ -32,7 +32,7 @@ define $(package)_set_vars
 $(package)_config_opts_release = -release
 $(package)_config_opts_debug = -debug
 $(package)_config_opts += -bindir $(build_prefix)/bin
-$(package)_config_opts += -c++std c++11
+$(package)_config_opts += -c++std c++1z
 $(package)_config_opts += -confirm-license
 $(package)_config_opts += -dbus-runtime
 $(package)_config_opts += -hostprefix $(build_prefix)
@@ -67,7 +67,6 @@ $(package)_config_opts += -nomake tests
 $(package)_config_opts += -opensource
 $(package)_config_opts += -openssl-linked
 $(package)_config_opts += -optimized-qmake
-$(package)_config_opts += -pch
 $(package)_config_opts += -pkg-config
 $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-libpng
@@ -180,6 +179,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_no_printer.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_rcc_determinism.patch &&\
   patch -p1 -i $($(package)_patch_dir)/xkb-default.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/fix_gcc_11_3_compile.patch &&\
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \

--- a/depends/patches/boost/fix_gcc_11_3_compile.patch
+++ b/depends/patches/boost/fix_gcc_11_3_compile.patch
@@ -1,0 +1,12 @@
+diff -Naur old/boost/thread/pthread/thread_data.hpp new/boost/thread/pthread/thread_data.hpp
+--- old/boost/thread/pthread/thread_data.hpp	2019-08-14 14:03:38.000000000 +0200
++++ new/boost/thread/pthread/thread_data.hpp	2022-10-08 21:33:40.351898197 +0200
+@@ -57,7 +57,7 @@
+ #else
+           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
+ #endif
+-#if PTHREAD_STACK_MIN > 0
++#ifdef PTHREAD_STACK_MIN
+           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
+ #endif
+           size = ((size+page_size-1)/page_size)*page_size;

--- a/depends/patches/qt/fix_gcc_11_3_compile.patch
+++ b/depends/patches/qt/fix_gcc_11_3_compile.patch
@@ -1,0 +1,22 @@
+diff -Naur old/qtbase/src/corelib/global/qfloat16.cpp new/qtbase/src/corelib/global/qfloat16.cpp
+--- old/qtbase/src/corelib/global/qfloat16.cpp	2019-12-03 13:50:08.000000000 +0100
++++ new/qtbase/src/corelib/global/qfloat16.cpp	2022-10-07 13:58:12.198990251 +0200
+@@ -37,6 +37,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qfloat16_p.h"
+ 
+ QT_BEGIN_NAMESPACE
+diff -Naur old/qtbase/src/corelib/tools/qbytearraymatcher.h new/qtbase/src/corelib/tools/qbytearraymatcher.h
+--- old/qtbase/src/corelib/tools/qbytearraymatcher.h	2019-12-03 13:50:08.000000000 +0100
++++ new/qtbase/src/corelib/tools/qbytearraymatcher.h	2022-10-07 11:45:51.333307586 +0200
+@@ -40,6 +40,7 @@
+ #ifndef QBYTEARRAYMATCHER_H
+ #define QBYTEARRAYMATCHER_H
+ 
++#include <limits>
+ #include <QtCore/qbytearray.h>
+ 
+ QT_BEGIN_NAMESPACE

--- a/src/crypto/google_authenticator.cpp
+++ b/src/crypto/google_authenticator.cpp
@@ -51,7 +51,7 @@ int GoogleAuthenticator::GeneratePin()
     return pin;
 }
 
-std::string GoogleAuthenticator::CreateNewSeed(uint size)
+std::string GoogleAuthenticator::CreateNewSeed(int size)
 {
     const char alphanum[] = "0123456789!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     int string_length = sizeof(alphanum) - 1;

--- a/src/crypto/google_authenticator.h
+++ b/src/crypto/google_authenticator.h
@@ -25,7 +25,7 @@ public:
 
     int GeneratePin();
 
-    static std::string CreateNewSeed(uint size = 20);
+    static std::string CreateNewSeed(int size = 20);
 };
 
 #endif // CRYPTO_GOOGLE_AUTHENTICATOR_H


### PR DESCRIPTION
This PR aims to fix `depends` compilation with gcc-11.3.0, gcc-12.2.1 and hopefully above.

It was tested and proven to build (depends + wallet against those depends) on:
- Fedora 37/glibc-2.36/gcc-12.2.1
- Gentoo 2.8/glibc-2.35/gcc-11.3.0 (hardened)
- Ubuntu 20.04.5/glibc-2.31/gcc-9.4.0
- Debian 10.10/glibc-2.28/gcc-8.3.0
- Ubuntu 16.04.7/glibc-2.23/gcc-10.3.0 (PPA upgraded)

All systems ran as Linux/64bit.

The static compilation flow was done as follows:

```
cd depends
make -jX
cd ..
./autogen.sh
CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --prefix=/$PWD/build-x86_64 --disable-tests --enable-glibc-back-compat LDFLAGS="-static-libstdc++"
make -jX && make install
```

Fedora was built without `LDFLAGS="-static-libstdc++`, most likely due to me not installing the right package for static stdc++.

Tests were disabled (`--disable-tests`), because as I noticed they are broken in DSW - independently on the build platform.

**PLEASE NOTE** that the update of `depends/packages/libevent.mk` breaks Decenomy standard of it's own GitHub depends sources storage and downloads `libevent` directly from their own releases. This can be easily modified once 2.1.12 source is deployed to Decenomy GitHub.

**PLEASE TEST on other platforms/systems before merging!**