### PR TITLE
force staking on by default for staking > 1

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1015,6 +1015,8 @@ bool AppInit2()
 
     setvbuf(stdout, NULL, _IOLBF, 0); /// ***TODO*** do we still need this after -printtoconsole is gone?
 
+    int64_t nStaking = GetArg("-staking", (int64_t)(!Params().IsRegTestNet() && DEFAULT_STAKING));
+
     // Staking needs a CWallet instance, so make sure wallet is enabled
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
@@ -1024,6 +1026,10 @@ bool AppInit2()
             LogPrintf("AppInit2 : parameter interaction: wallet functionality not enabled -> setting -staking=0\n");
 #ifdef ENABLE_WALLET
     } else {
+        if (nStaking > 1) {
+            fStakingActive = true;
+            LogPrintf("AppInit2: staking forced on by default, staking > 1\n");
+        }
         // Register wallet RPC commands
         walletRegisterRPCCommands();
     }
@@ -1786,8 +1792,8 @@ bool AppInit2()
     if (pwalletMain) {
         pwalletMain->postInitProcess(threadGroup);
 
-        fStaking = GetBoolArg("-staking", !Params().IsRegTestNet() && DEFAULT_STAKING);
         // StakeMiner thread disabled by default on regtest
+        fStaking = (bool)nStaking;
         if (fStaking) {
             threadGroup.create_thread(boost::bind(&ThreadStakeMinter));
         }

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -263,7 +263,7 @@ void BitcoinCore::initialize()
         qDebug() << __func__ << ": Running AppInit2 in thread";
         int rv = AppInit2();
         Q_EMIT initializeResult(rv);
-        fStakingActive = false;
+//        fStakingActive = false;
     } catch (const std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3480,7 +3480,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-gen", strprintf(_("Generate coins (default: %u)"), DEFAULT_GENERATE));
     strUsage += HelpMessageOpt("-genproclimit=<n>", strprintf(_("Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)"), DEFAULT_GENERATE_PROCLIMIT));
     strUsage += HelpMessageOpt("-minstakesplit=<amt>", strprintf(_("Minimum positive amount (in __DSW__) allowed by GUI and RPC for the stake split threshold (default: %s)"), FormatMoney(DEFAULT_MIN_STAKE_SPLIT_THRESHOLD)));
-    strUsage += HelpMessageOpt("-staking=<n>", strprintf(_("Enable staking functionality (0-1, default: %u)"), DEFAULT_STAKING));
+    strUsage += HelpMessageOpt("-staking=<n>", strprintf(_("Enable staking functionality (0, 1, >1, values greater than 1 force staking on by default, default: %u)"), DEFAULT_STAKING));
     if (showDebug) {
         strUsage += HelpMessageGroup(_("Wallet debugging/testing options:"));
         strUsage += HelpMessageOpt("-dblogsize=<n>", strprintf(_("Flush database activity from memory pool to disk log every <n> megabytes (default: %u)"), DEFAULT_WALLET_DBLOGSIZE));


### PR DESCRIPTION
This small patch allows users that are primarily staking to set the value

staking=2 or more

in the config file to force staking on by default on startup

fully tested in PNY for values of:

none (missing from file)
0, 1, 2, 99  with expected results