### PR TITLE
RPC: adds call to detect fork on chain

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -67,7 +67,8 @@ bool CBootstrap::DownloadAndApply()
 
     try {
         // Step 1: Download the bootstrap file
-        if (!CCurlWrapper::DownloadFile(url, fileName.string(), progressCallback)) {
+        CCurlWrapper client;
+        if (!client.DownloadFile(url, fileName.string(), progressCallback)) {
             LogPrintf(
                 "CBootstrap::%s: Failed to download the bootstrap file: %s\n",
                 __func__,

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -6,9 +6,15 @@
 
 #include "init.h"
 #include "logging.h"
+#include "fs.h"
+
+#include <openssl/md5.h>
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
 
 // Callback function to write downloaded data to a file
-size_t writeCallback(void* data, size_t size, size_t nmemb, void* clientp)
+size_t downloadWriteCallback(void* data, size_t size, size_t nmemb, void* clientp)
 {
     if(ShutdownRequested()) {
         LogPrintf(
@@ -23,20 +29,112 @@ size_t writeCallback(void* data, size_t size, size_t nmemb, void* clientp)
     return total_size;
 }
 
-bool CCurlWrapper::DownloadFile(
-    const std::string& url,
-    const std::string& filename,
-    curl_xferinfo_callback xferinfoCallback)
-{
-    try {
-        // Initializes libcurl
-        const auto curl = curl_easy_init();
-        if (!curl) {
-            LogPrintf(
-                "CCurlWrapper::%s: Error initializing libcurl.\n", __func__);
-            return false;
-        }
+// Callback function to append downloaded data from a request method
+size_t requestWriteCallback(void* ptr, size_t size, size_t nmemb, std::string* data) {
+    data->append((char*)ptr, size * nmemb);
+    return size * nmemb;
+}
 
+// Callback function to write received headers to a string
+size_t headerCallback(void* buffer, size_t size, size_t nmemb, std::string* headers) {
+    size_t totalSize = size * nmemb;
+    headers->append((char*)buffer, totalSize);
+    return totalSize;
+}
+
+std::string CalculateMD5(const std::string& filePath) {
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file) {
+        LogPrintf("-MD5: Error opening file: %s\n",filePath);
+        return "";
+    }
+
+    MD5_CTX mdContext;
+    MD5_Init(&mdContext);
+
+    const int bufferSize = 4096;
+    char buffer[bufferSize];
+    while (file) {
+        file.read(buffer, bufferSize);
+        MD5_Update(&mdContext, buffer, file.gcount());
+    }
+    file.close();
+
+    unsigned char digest[MD5_DIGEST_LENGTH];
+    MD5_Final(digest, &mdContext);
+
+    char md5String[MD5_DIGEST_LENGTH * 2 + 1];
+    for(int i = 0; i < MD5_DIGEST_LENGTH; i++)
+        sprintf(&md5String[i*2], "%02x", (unsigned int)digest[i]);
+
+    return md5String;
+}
+
+bool Base64Decode(const std::string &input, std::string &out) {
+    static constexpr unsigned char kDecodingTable[] = {
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53, 54, 55, 56, 57,
+        58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
+        7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 64, 64, 64, 64, 64, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+        37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64
+    };
+
+    size_t in_len = input.size();
+    if (in_len % 4 != 0)
+      return false;
+
+    size_t out_len = in_len / 4 * 3;
+    if (in_len >= 1 && input[in_len - 1] == '=')
+      out_len--;
+    if (in_len >= 2 && input[in_len - 2] == '=')
+      out_len--;
+
+    out.resize(out_len);
+
+    for (size_t i = 0, j = 0; i < in_len;) {
+        uint32_t a = input[i] == '='
+           ? 0 & i++
+           : kDecodingTable[static_cast<int>(input[i++])];
+        uint32_t b = input[i] == '='
+           ? 0 & i++
+           : kDecodingTable[static_cast<int>(input[i++])];
+        uint32_t c = input[i] == '='
+           ? 0 & i++
+           : kDecodingTable[static_cast<int>(input[i++])];
+        uint32_t d = input[i] == '='
+           ? 0 & i++
+           : kDecodingTable[static_cast<int>(input[i++])];
+
+        uint32_t triple =
+            (a << 3 * 6) + (b << 2 * 6) + (c << 1 * 6) + (d << 0 * 6);
+
+        if (j < out_len)
+            out[j++] = (triple >> 2 * 8) & 0xFF;
+        if (j < out_len)
+            out[j++] = (triple >> 1 * 8) & 0xFF;
+        if (j < out_len)
+            out[j++] = (triple >> 0 * 8) & 0xFF;
+    }
+
+    return true;
+}
+
+CCurlWrapper::CCurlWrapper() {
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl = curl_easy_init();
+    if (!curl) {
+        LogPrintf("CCurlWrapper::%s: Error initializing libcurl.\n", __func__);
+    }else{
         // Gets libcurl version information
         const auto info = curl_version_info(CURLVERSION_NOW);
         if (info) {
@@ -53,13 +151,39 @@ bool CCurlWrapper::DownloadFile(
             LogPrintf(
                 "CCurlWrapper::%s: Failed to retrieve libcurl version information.\n", 
                 __func__);
-            return false;
         }
+    }
+}
+
+CCurlWrapper::~CCurlWrapper() {
+    if (curl) {
+        curl_easy_cleanup(curl);
+    }
+    curl_global_cleanup();
+}
+
+bool CCurlWrapper::DownloadFile(
+    const std::string& url,
+    const std::string& filename,
+    curl_xferinfo_callback xferinfoCallback)
+{
+    try {
 
         LogPrintf(
             "CCurlWrapper::%s: Downloading from %s\n", 
             __func__,
             url);
+
+        if(fs::exists(filename))
+            fs::remove(filename);
+
+        // Try to set permissions
+        if(!GrantWritePermissions(fs::current_path())){
+            LogPrintf(
+            "CCurlWrapper::%s: Couldn't grant permissions for folder: %s\n", 
+            __func__,fs::current_path().string());
+            return false;
+        }
 
         // Creates and open the destination file
         std::ofstream outputFile(filename, std::ios::binary);
@@ -82,7 +206,7 @@ bool CCurlWrapper::DownloadFile(
 #endif
 
         // Sets file releated parameters
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, downloadWriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &outputFile);
 
         // Sets progress function parameters
@@ -95,12 +219,37 @@ bool CCurlWrapper::DownloadFile(
             curl_easy_setopt(curl, CURLOPT_XFERINFODATA, NULL); 
         }
 
+        // Follow redirects
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+        // Set the callback function to receive headers
+        std::string headers;
+        curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerCallback);
+        curl_easy_setopt(curl, CURLOPT_HEADERDATA, &headers);
+
+        const auto info = curl_version_info(CURLVERSION_NOW);
+        LogPrintf("curl: version: %s\n",info->version);
+        // Set User-Agent header
+        if (info) {
+            curl_easy_setopt(curl, CURLOPT_USERAGENT, info->version);
+        }
+
         // HTTP call execution
         const auto res = curl_easy_perform(curl);
 
-        // Cleanup
-        curl_easy_cleanup(curl);
         outputFile.close();
+
+        /* !! calculate md5hash if available
+        std::string hexMD5 = CalculateMD5(outputFileName);
+        std::cout << "calculated md5: " << hexMD5 << std::endl;
+
+        // get md5 from header
+        std::string headerMD5 = "Z+Ye9ExZ/IUfkl/Rb5piiQ==";
+        std::string decoded = "";
+        Base64Decode(headerMD5,decoded);
+        std::string hex = StringToHex(decoded);
+        std::cout << "headerMD5: " << hex << std::endl;
+        */
 
         // Evaluation and return
         if (res != CURLE_OK) {
@@ -121,4 +270,46 @@ bool CCurlWrapper::DownloadFile(
     }
 
     return true;
+}
+
+std::string CCurlWrapper::Request(const std::string& url) {
+
+    std::string response = "";
+    try {
+        LogPrintf("CCurlWrapper::%s: request: %s\n", __func__, url);
+        if (curl) {
+            curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L); // Verify the peer's SSL certificate
+            curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, requestWriteCallback);
+            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+#if defined(__APPLE__)
+            LogPrintf("CCurlWrapper::%s: apple ca path: %s\n", __func__, (const char*)APPLE_CA_PATH);
+            curl_easy_setopt(curl, CURLOPT_CAINFO, (const char*)APPLE_CA_PATH);
+#endif
+            
+            // Set User-Agent header
+            curl_version_info_data *info = curl_version_info(CURLVERSION_NOW);
+
+            if (info) {
+                curl_easy_setopt(curl, CURLOPT_USERAGENT, info->version);
+            }else{
+                 curl_easy_setopt(curl, CURLOPT_USERAGENT, "curl x.xx");
+            }
+            
+            CURLcode res = curl_easy_perform(curl);
+            if (res != CURLE_OK) {
+                LogPrintf("CCurlWrapper::%s: error: Failed to perform HTTP request: %s", __func__, curl_easy_strerror(res));
+            }
+        }
+    } catch (const std::exception& e) {
+        LogPrintf(
+            "CCurlWrapper::%s: Error requesting url: %s\n", 
+            __func__, e.what());
+        return "";
+    }
+
+    
+    return response;
 }

--- a/src/curl.h
+++ b/src/curl.h
@@ -13,10 +13,15 @@
 class CCurlWrapper
 {
 public:
-    static bool DownloadFile(
+    CCurlWrapper();
+    ~CCurlWrapper();
+    bool DownloadFile(
         const std::string& url,
         const std::string& filename,
         curl_xferinfo_callback xferinfoCallback = nullptr);
+    std::string Request(const std::string& url);
+private:
+    CURL* curl;
 };
 
 #endif // CURL_H

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -7,6 +7,13 @@
 #include "fs.h"
 
 #include <boost/filesystem.hpp>
+#include <openssl/sha.h>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif 
 
 namespace fsbridge {
 
@@ -21,3 +28,78 @@ FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
 }
 
 } // fsbridge
+
+bool GrantWritePermissions(const fs::path& path) {
+
+#ifdef _WIN32
+    try {
+        // Get the current permissions
+        fs::perms current_perms = fs::status(path).permissions();
+
+        // Add write permissions for owner, group, and others
+        fs::perms new_perms = current_perms
+                              | fs::perms::owner_write
+                              | fs::perms::group_write
+                              | fs::perms::others_write;
+
+        // Set the new permissions
+        fs::permissions(path, new_perms);
+
+        LogPrintf("%s: write permissions granted to: %s \n", __func__, path);
+        return true;
+    } catch (const fs::filesystem_error& e) {
+        LogPrintf("%s: Error updating permissions: %s\n", __func__, e.what());
+        return false;
+    }  
+#else
+    struct stat info;
+    if (stat(path.c_str(), &info) != 0) {
+        LogPrintf("%s: Error reading path stat\n", __func__);
+        return false;
+    }
+
+    mode_t new_mode = info.st_mode | S_IWUSR | S_IWGRP | S_IWOTH;
+    if (chmod(path.c_str(), new_mode) != 0) {
+        LogPrintf("%s: Error granting permissions chmod: %d\n", __func__, new_mode);
+    } else {
+        LogPrintf("%s: write permissions granted to: %s \n", __func__, path);
+        return true;
+    }
+#endif
+    return false;
+}
+
+std::string File_SHA256(const std::string& path){
+
+    std::ifstream fp(path, std::ios::in | std::ios::binary);
+
+    if (not fp.good()) {
+        LogPrintf("-SHA256::%s: Error: %s, Cannot open: %s\n",__func__, std::strerror(errno),path);
+        return "";
+    }
+
+    constexpr const std::size_t buffer_size { 1 << 12 };
+    char buffer[buffer_size];
+
+    unsigned char hash[SHA256_DIGEST_LENGTH] = { 0 };
+
+    SHA256_CTX ctx;
+    SHA256_Init(&ctx);
+
+    while (fp.good()) {
+        fp.read(buffer, buffer_size);
+        SHA256_Update(&ctx, buffer, fp.gcount());
+    }
+
+    SHA256_Final(hash, &ctx);
+    fp.close();
+
+    std::ostringstream os;
+    os << std::hex << std::setfill('0');
+
+    for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
+        os << std::setw(2) << static_cast<unsigned int>(hash[i]);
+    }
+
+return os.str();
+}

--- a/src/fs.h
+++ b/src/fs.h
@@ -7,6 +7,8 @@
 #ifndef BITCOIN_FS_H
 #define BITCOIN_FS_H
 
+#include "logging.h"
+
 #include <stdio.h>
 #include <string>
 
@@ -23,5 +25,8 @@ namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
 };
+
+std::string File_SHA256(const std::string& path);
+bool GrantWritePermissions(const fs::path& path);
 
 #endif

--- a/src/logging.h
+++ b/src/logging.h
@@ -21,6 +21,8 @@
 #include <mutex>
 #include <vector>
 
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -146,6 +146,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"getserials", 2},
         {"getfeeinfo", 0},
         {"getburnaddresses", 0},
+        {"detectfork", 0},
     };
 
 class CRPCConvertTable

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -321,6 +321,7 @@ static const CRPCCommand vRPCCommands[] =
         {"blockchain", "verifychain", &verifychain, true },
         {"blockchain", "getburnaddresses", &getburnaddresses, true },
         {"blockchain", "rewindblockindex", &rewindblockindex, true },
+        {"blockchain", "detectfork", &detectfork, true },
 
         /* Mining */
         {"mining", "getblocktemplate", &getblocktemplate, true },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -249,6 +249,7 @@ extern UniValue reconsiderblock(const JSONRPCRequest& request);
 extern UniValue getblockindexstats(const JSONRPCRequest& request);
 extern UniValue getburnaddresses(const JSONRPCRequest& request);
 extern UniValue rewindblockindex(const JSONRPCRequest& request);
+extern UniValue detectfork(const JSONRPCRequest& request);
 extern void validaterange(const UniValue& params, int& heightStart, int& heightEnd, int minHeightStart=1);
 
 // in rpc/masternode.cpp

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -702,3 +702,19 @@ std::string GetReadableHashRate(uint64_t hashrate)
     ss << std::setprecision(3) << std::fixed << readable << suffix;
     return ss.str();
 }
+
+std::string RemoveQuotes(const std::string& str) {
+    std::string result = str;
+
+    // Check if the string starts with a double quote
+    if (!result.empty() && result.front() == '"') {
+        result.erase(0, 1); // Erase the first character
+    }
+
+    // Check if the string ends with a double quote
+    if (!result.empty() && result.back() == '"') {
+        result.pop_back(); // Remove the last character
+    }
+
+    return result;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -203,4 +203,6 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
 
 std::string GetReadableHashRate(uint64_t hashrate);
 
+std::string RemoveQuotes(const std::string& str);
+
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
# **RPC FORK DETECTION**

## How to use it:
- __decenomy__-cli -blockchain detectfork 6

## How it works
Decrements the index passed as arg to the height of active chain
Gets current hash
Gets hash of the same block using API: https://explorer.decenomy.net/api/v2/
Compares with hash returned from API
Outputs the result in the following format:

{
  "nHeight": 1512302,
  "remoteBlockhash": "6d68da704db7eb1a90c4b52c00ae5e7538fdd61376c204d1c5e0bb584a3da501",
  "localBlockhash": "6d68da704db7eb1a90c4b52c00ae5e7538fdd61376c204d1c5e0bb584a3da501",
  "fForkDetected": "false"
}